### PR TITLE
Opt token are digits, not integers

### DIFF
--- a/two_factor/forms.py
+++ b/two_factor/forms.py
@@ -139,9 +139,10 @@ class DisableForm(forms.Form):
 
 
 class AuthenticationTokenForm(OTPAuthenticationFormMixin, Form):
-    otp_token = forms.IntegerField(label=_("Token"), min_value=1,
-                                   max_value=int('9' * totp_digits()))
-
+    otp_token = forms.RegexField(label=_("Token"),
+                                 regex=r'^[0-9]*$',
+                                 min_length=totp_digits(),
+                                 max_length=totp_digits())
     otp_token.widget.attrs.update({'autofocus': 'autofocus'})
 
     # Our authentication form has an additional submit button to go to the

--- a/two_factor/forms.py
+++ b/two_factor/forms.py
@@ -143,7 +143,10 @@ class AuthenticationTokenForm(OTPAuthenticationFormMixin, Form):
                                  regex=r'^[0-9]*$',
                                  min_length=totp_digits(),
                                  max_length=totp_digits())
-    otp_token.widget.attrs.update({'autofocus': 'autofocus'})
+    otp_token.widget.attrs.update({
+        'autofocus': 'autofocus',
+        'pattern': '[0-9]*', # hint to show numeric keyboard for on-screen keyboards
+    })
 
     # Our authentication form has an additional submit button to go to the
     # backup token form. When the `required` attribute is set on an input


### PR DESCRIPTION
Indeed, generated tokens can start with '0'. If we use an IntegerField into the form, the 0 will desapear and the value becomes invalid

## Description
<!--- Describe your changes in detail -->
Replace the IntergerField by RegexField for otp_token into AuthenticationTokenForm

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
 generated tokens can start with '0'. If we use an IntegerField into the form, the 0 will desapear and the value becomes invalid

## How Has This Been Tested?
Manual test: Tested by entering valid tokens starting with '0' and invalid tokens (alpha, length< totp_digits, length> totp_digits, ...)

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
