### PR TITLE
Avoid backup phone query if phones can't be used

### DIFF
--- a/two_factor/plugins/phonenumber/utils.py
+++ b/two_factor/plugins/phonenumber/utils.py
@@ -8,7 +8,12 @@ phone_mask = re.compile(r'(?<=.{3})[0-9](?=.{2})')
 
 
 def backup_phones(user):
-    if not user or user.is_anonymous:
+    no_gateways = (
+        getattr(settings, 'TWO_FACTOR_CALL_GATEWAY', None) is None
+        and getattr(settings, 'TWO_FACTOR_SMS_GATEWAY', None) is None)
+    no_user = not user or user.is_anonymous
+
+    if no_gateways or no_user:
         from .models import PhoneDevice
         return PhoneDevice.objects.none()
     return user.phonedevice_set.filter(name='backup')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
`backup_phones` now returns phones only if they can be used as backup.
## Description
<!--- Describe your changes in detail -->
Phones can't be used if there's no phone gateway configured. `backup_phones` should not return devices that aren't usable as second factor backups. This PR changes the `backup_phones` function accordingly.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change avoids an extra query to the DB for devices that will not be used as second factors if no phone gateway is configured.

<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
`UtilsTest.test_backup_phones` has been extended to also check that `backup_phones` returns an empty `QuerySet` when no phone gateway is configured.

<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
