### PR TITLE
Update django-phonenumber-field to newer version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Changed
 - Suppressed default_app_config warning on Django 3.2+
-- qrcode dependency limit upped to 7.99.
+- qrcode dependency limit upped to 7.99 and django-phonenumber-field to 7
 
 ## 1.13.1
 

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
         'Django>=2.2',
         'django_otp>=0.8.0',
         'qrcode>=4.0.0,<7.99',
-        'django-phonenumber-field>=1.1.0,<6',
+        'django-phonenumber-field>=1.1.0,<7',
         'django-formtools',
     ],
     extras_require={


### PR DESCRIPTION
Closes #439 

## Description
Allow django-phonenumber-field version <7
