### PR TITLE
When validating TOTP in TOTPDeviceForm, allow a drift in clocks of +/-1 instead of just -1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Changed
 - Suppressed default_app_config warning on Django 3.2+
 - qrcode dependency limit upped to 7.99 and django-phonenumber-field to 7
+- When validating a TOTP after scanning the QR code, allow a time drift of +/-1 instead of just -1
 
 ## 1.13.1
 

--- a/tests/test_totpdeviceform.py
+++ b/tests/test_totpdeviceform.py
@@ -1,5 +1,3 @@
-import unittest
-from unittest.mock import patch, MagicMock
 from binascii import unhexlify
 import time
 
@@ -32,7 +30,7 @@ class TOTPDeviceFormTest(UserMixin, TestCase):
         self.old_TOTP_init = old_TOTP_init
         def new_TOTP_init(self, key, step=30, t0=0, digits=6, drift=0):
         	old_TOTP_init(self, key, step, t0, digits, drift)
-        	self._time = TEST_TIME
+        	self.time = TEST_TIME
         django_otp.oath.TOTP.__init__ = new_TOTP_init
 
     def restore_time_for_totp(self):

--- a/tests/test_totpdeviceform.py
+++ b/tests/test_totpdeviceform.py
@@ -1,12 +1,7 @@
-import time
 from binascii import unhexlify
 
 import django_otp.oath
-from django import forms
-from django.conf import settings
-from django.shortcuts import resolve_url
 from django.test import TestCase
-from django.urls import reverse
 
 from two_factor.forms import TOTPDeviceForm
 
@@ -16,6 +11,7 @@ from .utils import UserMixin
 # as 3 Jan 2022
 TEST_TIME = 1641194517
 
+
 # This class test how the TOTPDeviceForm validator handles drift between its clock
 # and the TOTP device.  If there is a drift in the range [-tolerance, +tolerance],
 # where tolerance is hardcoded to 1, then the TOTP should be accepted.  Outside this
@@ -24,13 +20,14 @@ class TOTPDeviceFormTest(UserMixin, TestCase):
     key = '12345678901234567890'
 
     def fix_time_for_totp(self):
-    	# Override constructor for TOTP class to set a fixed time.  This will
-    	# prevent it from calling time(), which would make the unittest unpredictable
+        # Override constructor for TOTP class to set a fixed time.  This will
+        # prevent it from calling time(), which would make the unittest unpredictable
         old_TOTP_init = django_otp.oath.TOTP.__init__
         self.old_TOTP_init = old_TOTP_init
+
         def new_TOTP_init(self, key, step=30, t0=0, digits=6, drift=0):
-        	old_TOTP_init(self, key, step, t0, digits, drift)
-        	self.time = TEST_TIME
+            old_TOTP_init(self, key, step, t0, digits, drift)
+            self.time = TEST_TIME
         django_otp.oath.TOTP.__init__ = new_TOTP_init
 
     def restore_time_for_totp(self):
@@ -47,35 +44,35 @@ class TOTPDeviceFormTest(UserMixin, TestCase):
         self.restore_time_for_totp()
 
     def totp_with_offset(self, offset):
-        return django_otp.oath.totp(self.bin_key, self.empty_form.step, 
-        	self.empty_form.t0, self.empty_form.digits, self.empty_form.drift + offset)
+        return django_otp.oath.totp(self.bin_key, self.empty_form.step,
+            self.empty_form.t0, self.empty_form.digits, self.empty_form.drift + offset)
 
     def test_offset_0(self):
         device_totp = self.totp_with_offset(0)
-        self.form = TOTPDeviceForm(TOTPDeviceFormTest.key, None, 
-        	data={'token': device_totp})
+        self.form = TOTPDeviceForm(TOTPDeviceFormTest.key, None,
+            data={'token': device_totp})
         self.assertTrue(self.form.is_valid())
 
     def test_offset_minus1(self):
         device_totp = self.totp_with_offset(-1)
-        self.form = TOTPDeviceForm(TOTPDeviceFormTest.key, None, 
-        	data={'token': device_totp})
+        self.form = TOTPDeviceForm(TOTPDeviceFormTest.key, None,
+            data={'token': device_totp})
         self.assertTrue(self.form.is_valid())
 
     def test_offset_plus1(self):
         device_totp = self.totp_with_offset(1)
-        self.form = TOTPDeviceForm(TOTPDeviceFormTest.key, None, 
-        	data={'token': device_totp})
+        self.form = TOTPDeviceForm(TOTPDeviceFormTest.key, None,
+            data={'token': device_totp})
         self.assertTrue(self.form.is_valid())
 
-    def test_offset_minus1(self):
+    def test_offset_minus2(self):
         device_totp = self.totp_with_offset(-2)
-        self.form = TOTPDeviceForm(TOTPDeviceFormTest.key, None, 
-        	data={'token': device_totp})
+        self.form = TOTPDeviceForm(TOTPDeviceFormTest.key, None,
+            data={'token': device_totp})
         self.assertFalse(self.form.is_valid())
 
     def test_offset_plus2(self):
         device_totp = self.totp_with_offset(2)
-        self.form = TOTPDeviceForm(TOTPDeviceFormTest.key, None, 
-        	data={'token': device_totp})
+        self.form = TOTPDeviceForm(TOTPDeviceFormTest.key, None,
+            data={'token': device_totp})
         self.assertFalse(self.form.is_valid())

--- a/tests/test_totpdeviceform.py
+++ b/tests/test_totpdeviceform.py
@@ -1,12 +1,12 @@
-from binascii import unhexlify
 import time
+from binascii import unhexlify
 
+import django_otp.oath
 from django import forms
 from django.conf import settings
 from django.shortcuts import resolve_url
 from django.test import TestCase
 from django.urls import reverse
-import django_otp.oath 
 
 from two_factor.forms import TOTPDeviceForm
 

--- a/tests/test_totpdeviceform.py
+++ b/tests/test_totpdeviceform.py
@@ -1,0 +1,83 @@
+import unittest
+from unittest.mock import patch, MagicMock
+from binascii import unhexlify
+import time
+
+from django import forms
+from django.conf import settings
+from django.shortcuts import resolve_url
+from django.test import TestCase
+from django.urls import reverse
+import django_otp.oath 
+
+from two_factor.forms import TOTPDeviceForm
+
+from .utils import UserMixin
+
+# Use this as the Unix time for all TOTPs.  It is chosen arbitrarily
+# as 3 Jan 2021
+TEST_TIME = 1641194517
+
+# This class test how the TOTPDeviceForm validator handles drift between its clock
+# and the TOTP device.  If there is a drift in the range [-tolerance, +tolerance],
+# where tolerance is hardcoded to 1, then the TOTP should be accepted.  Outside this
+# range, it should be rejected.
+class TOTPDeviceFormTest(UserMixin, TestCase):
+    key = '12345678901234567890'
+
+    def fix_time_for_totp(self):
+    	# Override constructor for TOTP class to set a fixed time.  This will
+    	# prevent it from calling time(), which would make the unittest unpredictable
+        old_TOTP_init = django_otp.oath.TOTP.__init__
+        self.old_TOTP_init = old_TOTP_init
+        def new_TOTP_init(self, key, step=30, t0=0, digits=6, drift=0):
+        	old_TOTP_init(self, key, step, t0, digits, drift)
+        	self._time = TEST_TIME
+        django_otp.oath.TOTP.__init__ = new_TOTP_init
+
+    def restore_time_for_totp(self):
+        django_otp.oath.TOTP.__init__ = self.old_TOTP_init
+
+    def setUp(self):
+        super().setUp()
+        self.fix_time_for_totp()
+        self.bin_key = unhexlify(TOTPDeviceFormTest.key.encode())
+        self.empty_form = TOTPDeviceForm(TOTPDeviceFormTest.key, None)
+
+    def tearDown(self):
+        super().tearDown()
+        self.restore_time_for_totp()
+
+    def totp_with_offset(self, offset):
+        return django_otp.oath.totp(self.bin_key, self.empty_form.step, 
+        	self.empty_form.t0, self.empty_form.digits, self.empty_form.drift + offset)
+
+    def test_offset_0(self):
+        device_totp = self.totp_with_offset(0)
+        self.form = TOTPDeviceForm(TOTPDeviceFormTest.key, None, 
+        	data={'token': device_totp})
+        self.assertTrue(self.form.is_valid())
+
+    def test_offset_minus1(self):
+        device_totp = self.totp_with_offset(-1)
+        self.form = TOTPDeviceForm(TOTPDeviceFormTest.key, None, 
+        	data={'token': device_totp})
+        self.assertTrue(self.form.is_valid())
+
+    def test_offset_plus1(self):
+        device_totp = self.totp_with_offset(1)
+        self.form = TOTPDeviceForm(TOTPDeviceFormTest.key, None, 
+        	data={'token': device_totp})
+        self.assertTrue(self.form.is_valid())
+
+    def test_offset_minus1(self):
+        device_totp = self.totp_with_offset(-2)
+        self.form = TOTPDeviceForm(TOTPDeviceFormTest.key, None, 
+        	data={'token': device_totp})
+        self.assertFalse(self.form.is_valid())
+
+    def test_offset_plus2(self):
+        device_totp = self.totp_with_offset(2)
+        self.form = TOTPDeviceForm(TOTPDeviceFormTest.key, None, 
+        	data={'token': device_totp})
+        self.assertFalse(self.form.is_valid())

--- a/tests/test_totpdeviceform.py
+++ b/tests/test_totpdeviceform.py
@@ -1,78 +1,70 @@
 from binascii import unhexlify
+from unittest.mock import patch
 
 import django_otp.oath
 from django.test import TestCase
 
 from two_factor.forms import TOTPDeviceForm
 
-from .utils import UserMixin
-
 # Use this as the Unix time for all TOTPs.  It is chosen arbitrarily
 # as 3 Jan 2022
 TEST_TIME = 1641194517
 
 
-# This class test how the TOTPDeviceForm validator handles drift between its clock
-# and the TOTP device.  If there is a drift in the range [-tolerance, +tolerance],
-# where tolerance is hardcoded to 1, then the TOTP should be accepted.  Outside this
-# range, it should be rejected.
-class TOTPDeviceFormTest(UserMixin, TestCase):
+@patch('django_otp.oath.time', return_value=TEST_TIME)
+class TOTPDeviceFormTest(TestCase):
+    """
+    This class tests how the TOTPDeviceForm validator handles drift between its clock
+    and the TOTP device.
+
+    If there is a drift in the range [-tolerance, +tolerance], (tolerance is hardcoded
+    to 1), then the TOTP should be accepted.  Outside this range, it should be rejected.
+    """
+
     key = '12345678901234567890'
-
-    def fix_time_for_totp(self):
-        # Override constructor for TOTP class to set a fixed time.  This will
-        # prevent it from calling time(), which would make the unittest unpredictable
-        old_TOTP_init = django_otp.oath.TOTP.__init__
-        self.old_TOTP_init = old_TOTP_init
-
-        def new_TOTP_init(self, key, step=30, t0=0, digits=6, drift=0):
-            old_TOTP_init(self, key, step, t0, digits, drift)
-            self.time = TEST_TIME
-        django_otp.oath.TOTP.__init__ = new_TOTP_init
 
     def restore_time_for_totp(self):
         django_otp.oath.TOTP.__init__ = self.old_TOTP_init
 
     def setUp(self):
         super().setUp()
-        self.fix_time_for_totp()
         self.bin_key = unhexlify(TOTPDeviceFormTest.key.encode())
         self.empty_form = TOTPDeviceForm(TOTPDeviceFormTest.key, None)
-
-    def tearDown(self):
-        super().tearDown()
-        self.restore_time_for_totp()
 
     def totp_with_offset(self, offset):
         return django_otp.oath.totp(self.bin_key, self.empty_form.step,
             self.empty_form.t0, self.empty_form.digits, self.empty_form.drift + offset)
 
-    def test_offset_0(self):
+    def test_offset_0(self, mock_test):
         device_totp = self.totp_with_offset(0)
-        self.form = TOTPDeviceForm(TOTPDeviceFormTest.key, None,
+        form = TOTPDeviceForm(TOTPDeviceFormTest.key, None,
             data={'token': device_totp})
-        self.assertTrue(self.form.is_valid())
+        self.assertTrue(form.is_valid())
 
-    def test_offset_minus1(self):
+    def test_offset_minus1(self, mock_test):
         device_totp = self.totp_with_offset(-1)
-        self.form = TOTPDeviceForm(TOTPDeviceFormTest.key, None,
+        form = TOTPDeviceForm(TOTPDeviceFormTest.key, None,
             data={'token': device_totp})
-        self.assertTrue(self.form.is_valid())
+        self.assertTrue(form.is_valid())
 
-    def test_offset_plus1(self):
+    def test_offset_plus1(self, mock_test):
         device_totp = self.totp_with_offset(1)
-        self.form = TOTPDeviceForm(TOTPDeviceFormTest.key, None,
+        form = TOTPDeviceForm(TOTPDeviceFormTest.key, None,
             data={'token': device_totp})
-        self.assertTrue(self.form.is_valid())
+        self.assertTrue(form.is_valid())
 
-    def test_offset_minus2(self):
+    def test_offset_minus2(self, mock_test):
         device_totp = self.totp_with_offset(-2)
-        self.form = TOTPDeviceForm(TOTPDeviceFormTest.key, None,
+        form = TOTPDeviceForm(TOTPDeviceFormTest.key, None,
             data={'token': device_totp})
-        self.assertFalse(self.form.is_valid())
+        self.assertFalse(form.is_valid())
+        self.assertEqual(form.errors['token'][0],
+            TOTPDeviceForm.error_messages['invalid_token'])
 
-    def test_offset_plus2(self):
+    def test_offset_plus2(self, mock_test):
         device_totp = self.totp_with_offset(2)
-        self.form = TOTPDeviceForm(TOTPDeviceFormTest.key, None,
+        form = TOTPDeviceForm(TOTPDeviceFormTest.key, None,
             data={'token': device_totp})
-        self.assertFalse(self.form.is_valid())
+        self.assertFalse(form.is_valid())
+        self.assertEqual(form.errors['token'][0],
+            TOTPDeviceForm.error_messages['invalid_token'])

--- a/tests/test_totpdeviceform.py
+++ b/tests/test_totpdeviceform.py
@@ -23,9 +23,6 @@ class TOTPDeviceFormTest(TestCase):
 
     key = '12345678901234567890'
 
-    def restore_time_for_totp(self):
-        django_otp.oath.TOTP.__init__ = self.old_TOTP_init
-
     def setUp(self):
         super().setUp()
         self.bin_key = unhexlify(TOTPDeviceFormTest.key.encode())

--- a/tests/test_totpdeviceform.py
+++ b/tests/test_totpdeviceform.py
@@ -13,7 +13,7 @@ from two_factor.forms import TOTPDeviceForm
 from .utils import UserMixin
 
 # Use this as the Unix time for all TOTPs.  It is chosen arbitrarily
-# as 3 Jan 2021
+# as 3 Jan 2022
 TEST_TIME = 1641194517
 
 # This class test how the TOTPDeviceForm validator handles drift between its clock

--- a/two_factor/forms.py
+++ b/two_factor/forms.py
@@ -125,7 +125,7 @@ class TOTPDeviceForm(forms.Form):
         if 'valid_t0' in self.metadata:
             t0s.append(int(time()) - self.metadata['valid_t0'])
         for t0 in t0s:
-            for offset in range(-self.tolerance, self.tolerance):
+            for offset in range(-self.tolerance, self.tolerance+1):
                 if totp(key, self.step, t0, self.digits, self.drift + offset) == token:
                     self.drift = offset
                     self.metadata['valid_t0'] = int(time()) - t0

--- a/two_factor/forms.py
+++ b/two_factor/forms.py
@@ -125,7 +125,7 @@ class TOTPDeviceForm(forms.Form):
         if 'valid_t0' in self.metadata:
             t0s.append(int(time()) - self.metadata['valid_t0'])
         for t0 in t0s:
-            for offset in range(-self.tolerance, self.tolerance+1):
+            for offset in range(-self.tolerance, self.tolerance + 1):
                 if totp(key, self.step, t0, self.digits, self.drift + offset) == token:
                     self.drift = offset
                     self.metadata['valid_t0'] = int(time()) - t0


### PR DESCRIPTION


## Description

When validating a TOTP, the TOTPDeviceForm class allows for a clock drift defined by the instance variable tolerance, hardcoded to 1.  While looping of values within this tolerance, the loop started at -tolerance but ended at tolerance-1 instead of tolerance.

A test class is also added.  It sets the time in the TOTP class to a constant value (to make tests deterministic), and confirms the TOTP is accepted when there is an offset of -1, 0 or 1 between the clocks and that it is not accepted when the offset is -2 or +2.

## Motivation and Context
I found when registering and authenticator for the first time, I could only very rarely get the initial TOTP to validate until I made this change.

The change makes the loop the same as in [this example](https://python.hotexamples.com/examples/django_otp.oath/TOTP/drift/python-totp-drift-method-examples.html).

Closes #455 

## How Has This Been Tested?
New test class added as described above.  This confirms it works for the offset values it should work for, and not for one value either side.
All existing tests continue to succeed.  Tested with Python 3.9 on Mac.


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
