### PR TITLE
Stop making universal builds

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,3 @@ line_length = 79
 multi_line_output = 5
 not_skip = __init__.py
 sections=FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
-
-
-[wheel]
-universal = 1


### PR DESCRIPTION
Only Python 3 is supported by django-two-factor-auth.