### PR TITLE
Cache default device onto user object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ### Added
 - Python 3.10 support
 
+### Changed
+- default_device utility function now caches the found device on the given user object
+
 ### Removed
 - Python 3.5 and 3.6 support
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,7 +7,8 @@ from django_otp.util import random_hex
 
 from two_factor.models import PhoneDevice
 from two_factor.utils import (
-    backup_phones, default_device, get_otpauth_url, totp_digits,
+    USER_DEFAULT_DEVICE_ATTR_NAME, backup_phones, default_device,
+    get_otpauth_url, totp_digits,
 )
 from two_factor.views.utils import (
     get_remember_device_cookie, salted_hmac_sha256,
@@ -27,6 +28,12 @@ class UtilsTest(UserMixin, TestCase):
 
         default = user.phonedevice_set.create(name='default', number='+12024561111')
         self.assertEqual(default_device(user).pk, default.pk)
+        self.assertEqual(getattr(user, USER_DEFAULT_DEVICE_ATTR_NAME).pk, default.pk)
+
+        # double check we're actually caching
+        PhoneDevice.objects.all().delete()
+        self.assertEqual(default_device(user).pk, default.pk)
+        self.assertEqual(getattr(user, USER_DEFAULT_DEVICE_ATTR_NAME).pk, default.pk)
 
     def test_backup_phones(self):
         self.assertQuerysetEqual(list(backup_phones(None)),

--- a/two_factor/utils.py
+++ b/two_factor/utils.py
@@ -5,12 +5,17 @@ from django_otp import devices_for_user
 
 from two_factor.models import PhoneDevice
 
+USER_DEFAULT_DEVICE_ATTR_NAME = "_default_device"
+
 
 def default_device(user):
     if not user or user.is_anonymous:
         return
+    if hasattr(user, USER_DEFAULT_DEVICE_ATTR_NAME):
+        return getattr(user, USER_DEFAULT_DEVICE_ATTR_NAME)
     for device in devices_for_user(user):
         if device.name == 'default':
+            setattr(user, USER_DEFAULT_DEVICE_ATTR_NAME, device)
             return device
 
 


### PR DESCRIPTION
Reduces database queries during login

Fixes #465

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

- For logged in users, cache the default 2FA device onto the user object
- Anonymous users are unaffected as they don't cause any database queries

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

`default_device` is called multiple times during various views in django-two-factor-auth. In particular, it appears to be the cause of the excessive database queries found in #465 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Added to tests already present

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
