### PR TITLE
Removed not_skip isort config as it is deprecated in isort 5

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -10,5 +10,4 @@ include_trailing_comma = true
 known_first_party = two_factor
 line_length = 79
 multi_line_output = 5
-not_skip = __init__.py
 sections=FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER


### PR DESCRIPTION
From the 5.0.0 Changelog:
Since there is no longer composition negative form settings (such as --dont-skip
or it's config file variant not_skip) are no longer required and have been removed.