### PR TITLE
Set idempotent attribute at form level

### DIFF
--- a/tests/urls.py
+++ b/tests/urls.py
@@ -9,6 +9,11 @@ from .views import SecureView
 
 urlpatterns = [
     path(
+        'account/login/',
+        LoginView.as_view(),
+        name='login',
+    ),
+    path(
         'account/logout/',
         LogoutView.as_view(),
         name='logout',

--- a/two_factor/forms.py
+++ b/two_factor/forms.py
@@ -121,6 +121,7 @@ class AuthenticationTokenForm(OTPAuthenticationFormMixin, forms.Form):
     # solution would be to move the button outside the `<form>` and into
     # its own `<form>`.
     use_required_attribute = False
+    idempotent = False
 
     def __init__(self, user, initial_device, **kwargs):
         """

--- a/two_factor/plugins/yubikey/forms.py
+++ b/two_factor/plugins/yubikey/forms.py
@@ -10,6 +10,7 @@ class YubiKeyDeviceForm(DeviceValidationForm):
     error_messages = {
         'invalid_token': _("The YubiKey could not be verified."),
     }
+    idempotent = False
 
     def clean_token(self):
         self.device.public_id = self.cleaned_data['token'][:-32]

--- a/two_factor/views/core.py
+++ b/two_factor/views/core.py
@@ -80,10 +80,6 @@ class LoginView(SuccessURLAllowedHostsMixin, IdempotentSessionWizardView):
         ('token', AuthenticationTokenForm),
         ('backup', BackupTokenForm),
     )
-    idempotent_dict = {
-        'token': False,
-        'backup': False,
-    }
     redirect_authenticated_user = False
     storage_name = 'two_factor.views.utils.LoginStorage'
 
@@ -413,9 +409,6 @@ class SetupView(IdempotentSessionWizardView):
         ('method', MethodForm),
         # Other forms are dynamically added in get_form_list()
     )
-    idempotent_dict = {
-        'yubikey': False,
-    }
 
     def get_method(self):
         method_data = self.storage.validated_step_data.get('method', {})


### PR DESCRIPTION
This small refactoring is helping separate core and plugin concerns as idempotence can be defined on the forms themselves.

This is also a preparation for the future email plugin.