### PR TITLE
Email 2fa through django_otp email plugin

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -97,6 +97,18 @@ setting. Then, you may want to configure the following settings:
   multiplied by this factor to define the delay imposed after 1, 2, 3, 4...
   successive failures. Set to ``0`` to disable throttling completely.
 
+Email Gateway
+-------------
+
+To enable receiving authentication tokens by email, you have to add
+``'django_otp.plugins.otp_totp'`` to your ``INSTALLED_APPS`` setting. Also
+ensure that the DEFAULT_FROM_EMAIL_ settings is configured with an appropriate
+value.
+
+Read the `Email Settings`_ section of the ``django_otp`` documentation to find
+about possible email-related customizations (subject/body of messages,
+throttling, etc.).
+
 Twilio Gateway
 --------------
 To use the Twilio gateway, you need first to install the `Twilio client`_:
@@ -141,6 +153,8 @@ Fake Gateway
 .. _LOGIN_URL: https://docs.djangoproject.com/en/dev/ref/settings/#login-url
 .. _LOGIN_REDIRECT_URL: https://docs.djangoproject.com/en/dev/ref/settings/#login-redirect-url
 .. _LOGOUT_REDIRECT_URL: https://docs.djangoproject.com/en/dev/ref/settings/#logout-redirect-url
+.. _DEFAULT_FROM_EMAIL: https://docs.djangoproject.com/en/stable/ref/settings/#default-from-email
+.. _`Email Settings`: https://django-otp-official.readthedocs.io/en/stable/overview.html#email-settings
 .. _Twilio: http://www.twilio.com/
 .. _`Twilio client`: https://pypi.python.org/pypi/twilio
 .. _python-qrcode: https://pypi.python.org/pypi/qrcode

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -33,6 +33,7 @@ Add the following apps to the ``INSTALLED_APPS``:
         'django_otp',
         'django_otp.plugins.otp_static',
         'django_otp.plugins.otp_totp',
+        'django_otp.plugins.otp_email',  # <- if you want email capability.
         'two_factor',
         'two_factor.plugins.phonenumber',  # <- if you want phone number capability.
         'two_factor.plugins.yubikey',  # <- for yubikey capability.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -36,6 +36,7 @@ Add the following apps to the ``INSTALLED_APPS``:
         'django_otp.plugins.otp_email',  # <- if you want email capability.
         'two_factor',
         'two_factor.plugins.phonenumber',  # <- if you want phone number capability.
+        'two_factor.plugins.email',  # <- if you want email capability.
         'two_factor.plugins.yubikey',  # <- for yubikey capability.
     )
 

--- a/example/settings.py
+++ b/example/settings.py
@@ -103,6 +103,7 @@ TWO_FACTOR_REMEMBER_COOKIE_AGE = 120  # Set to 2 minute for testing
 SESSION_ENGINE = 'user_sessions.backends.db'
 
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+DEFAULT_FROM_EMAIL = 'webmaster@example.org'
 
 SILENCED_SYSTEM_CHECKS = ['admin.E410']
 

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -18,6 +18,7 @@ INSTALLED_APPS = [
     'django_otp',
     'django_otp.plugins.otp_static',
     'django_otp.plugins.otp_totp',
+    'django_otp.plugins.otp_email',
     'two_factor',
     'two_factor.plugins.phonenumber',
     'tests',
@@ -79,3 +80,6 @@ TWO_FACTOR_PATCH_ADMIN = False
 
 AUTH_USER_MODEL = os.environ.get('AUTH_USER_MODEL', 'auth.User')
 PASSWORD_HASHERS = ['django.contrib.auth.hashers.MD5PasswordHasher']
+
+EMAIL_BACKEND = 'django.core.mail.backends.locmem.EmailBackend'
+DEFAULT_FROM_EMAIL = 'test@test.org'

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -20,6 +20,7 @@ INSTALLED_APPS = [
     'django_otp.plugins.otp_totp',
     'django_otp.plugins.otp_email',
     'two_factor',
+    'two_factor.plugins.email',
     'two_factor.plugins.phonenumber',
     'tests',
 ]

--- a/tests/test_email.py
+++ b/tests/test_email.py
@@ -92,8 +92,6 @@ class EmailTest(UserMixin, TestCase):
         response = self.client.post(reverse('two_factor:setup'),
                                     data={'setup_view-current_step': 'validation',
                                     'validation-token': token})
-        if response.status_code == 200:
-            self.fail(response.context['form'].errors)
         self.assertRedirects(response, reverse('two_factor:setup_complete'))
 
         # Now the user has a default 2FA device that is an EmailDevice.

--- a/tests/test_email.py
+++ b/tests/test_email.py
@@ -1,0 +1,179 @@
+import re
+from unittest import mock
+
+from django.conf import settings
+from django.core import mail
+from django.shortcuts import resolve_url
+from django.test import TestCase
+from django.test.utils import override_settings
+from django.urls import reverse
+from django_otp import DEVICE_ID_SESSION_KEY
+from django_otp.plugins.otp_email.models import EmailDevice
+
+from .utils import UserMixin, default_device
+
+
+class EmailTest(UserMixin, TestCase):
+    def setUp(self):
+        super().setUp()
+        self.user = self.create_user()
+        self.login_user()
+
+    def test_have_email_method(self):
+        response = self.client.post(reverse('two_factor:setup'),
+                                    data={'setup_view-current_step': 'welcome'})
+        self.assertContains(
+            response,
+            '<input type="radio" name="method-method" value="email" required id="id_method-method_1">',
+            html=True
+        )
+
+    @mock.patch('django.db.models.signals.post_save.send')
+    @override_settings(OTP_EMAIL_THROTTLE_FACTOR=0)
+    def test_setup(self, signals):
+        response = self.client.post(reverse('two_factor:setup'),
+                                    data={'setup_view-current_step': 'welcome'})
+        self.assertContains(response, 'Method:')
+        self.assertContains(response, 'Email')
+        self.assertEqual(len(mail.outbox), 0)
+
+        # Right now, the user does not have a default 2FA device.
+        self.assertEqual(default_device(self.user), None)
+
+        # assert that if user email not empty skip email form
+        response = self.client.post(reverse('two_factor:setup'),
+                                    data={'setup_view-current_step': 'method',
+                                    'method-method': 'email'})
+        self.assertContains(response, 'Token:')
+        self.assertEqual(len(mail.outbox), 1)
+        msg = mail.outbox.pop(0)
+        self.assertEqual(msg.subject, 'OTP token')
+
+        # assert that if user email empty ask email
+        self.user.email = ''
+        self.user.save()
+        response = self.client.post(reverse('two_factor:setup'),
+                                    data={'setup_view-current_step': 'method',
+                                    'method-method': 'email'})
+        self.assertContains(response, 'Email address:')
+
+        response = self.client.post(reverse('two_factor:setup'),
+                                    data={'setup_view-current_step': 'email'})
+        self.assertEqual(response.context_data['wizard']['form'].errors,
+                         {'email': ['This field is required.']})
+
+        response = self.client.post(reverse('two_factor:setup'),
+                                    data={'setup_view-current_step': 'email',
+                                    'email-email': 'bouke'})
+        self.assertEqual(response.context_data['wizard']['form'].errors,
+                         {'email': ['Enter a valid email address.']})
+
+        response = self.client.post(reverse('two_factor:setup'),
+                                    data={'setup_view-current_step': 'email',
+                                          'email-email': 'bouke@example.com'})
+
+        # Test that one message has been sent.
+        self.assertEqual(len(mail.outbox), 1)
+        msg = mail.outbox.pop(0)
+        self.assertEqual(['bouke@example.com'], msg.to)
+        self.assertEqual('OTP token', msg.subject)
+        self.assertRegex(msg.body, r'[0-9]{6}')
+
+        token = re.findall(r'[0-9]{6}', msg.body)[0]
+
+        # assert that tokens are verified
+        response = self.client.post(reverse('two_factor:setup'),
+                                    data={'setup_view-current_step': 'validation',
+                                    'validation-token': '666'})
+        self.assertEqual(response.context_data['wizard']['form'].errors,
+                         {'token': ['Entered token is not valid.']})
+
+        # submitting correct token should finish the setup
+        response = self.client.post(reverse('two_factor:setup'),
+                                    data={'setup_view-current_step': 'validation',
+                                    'validation-token': token})
+        if response.status_code == 200:
+            self.fail(response.context['form'].errors)
+        self.assertRedirects(response, reverse('two_factor:setup_complete'))
+
+        # Now the user has a default 2FA device that is an EmailDevice.
+        device = default_device(self.user)
+        self.assertIsNotNone(device)
+        self.assertIsInstance(device, EmailDevice)
+
+        # Check save user on success.
+        self.assertIn(
+            mock.call(created=False,
+                      instance=self.user,
+                      raw=mock.ANY,
+                      sender=self.User,
+                      update_fields=frozenset({'email'}),
+                      using=mock.ANY),
+            signals.mock_calls)
+
+    @override_settings(OTP_EMAIL_SUBJECT='Test subject')
+    @override_settings(OTP_EMAIL_BODY_TEMPLATE='Test text')
+    def test_subject_and_text(self):
+        self.user.emaildevice_set.create(name='default')
+        response = self.client.post(reverse('two_factor:login'),
+                                    {'auth-username': 'bouke@example.com',
+                                     'auth-password': 'secret',
+                                     'login_view-current_step': 'auth'})
+        self.assertContains(response, 'Token:')
+
+        self.assertEqual(len(mail.outbox), 1)
+        msg = mail.outbox.pop(0)
+        self.assertIn('Test subject', msg.subject)
+        self.assertIn('Test text', msg.body)
+
+    @override_settings(TWO_FACTOR_EMAIL_HTML=False)
+    def test_no_alternative(self):
+        self.user.emaildevice_set.create(name='default')
+        response = self.client.post(reverse('two_factor:login'),
+                                    {'auth-username': 'bouke@example.com',
+                                     'auth-password': 'secret',
+                                     'login_view-current_step': 'auth'})
+        self.assertContains(response, 'Token:')
+
+        self.assertEqual(len(mail.outbox), 1)
+        msg = mail.outbox.pop(0)
+        self.assertEqual(len(msg.alternatives), 0)
+
+    @mock.patch('two_factor.views.core.signals.user_verified.send')
+    @override_settings(OTP_EMAIL_THROTTLE_FACTOR=0)
+    def test_login(self, mock_signal):
+        device = self.user.emaildevice_set.create(name='default')
+
+        response = self.client.post(reverse('two_factor:login'),
+                                    {'auth-username': 'bouke@example.com',
+                                     'auth-password': 'secret',
+                                     'login_view-current_step': 'auth'})
+
+        self.assertContains(response, 'Token:')
+        # Test that one message has been sent.
+        self.assertEqual(len(mail.outbox), 1)
+        msg = mail.outbox.pop(0)
+        self.assertIn('OTP token', msg.subject)
+        self.assertEqual(msg.recipients(), ['bouke@example.com'])
+        self.assertEqual(msg.from_email, 'test@test.org')
+
+        response = self.client.post(reverse('two_factor:login'),
+                                    {'token-otp_token': 'a23456',
+                                     'login_view-current_step': 'token'})
+
+        self.assertEqual(response.context_data['wizard']['form'].errors,
+                         {'__all__': ['Invalid token. Please make sure you '
+                                      'have entered it correctly.']})
+
+        token = re.findall(r'[0-9]{6}', msg.body)[0]
+        response = self.client.post(reverse('two_factor:login'),
+                                    {'token-otp_token': token,
+                                     'login_view-current_step': 'token'})
+        self.assertRedirects(response, resolve_url(settings.LOGIN_REDIRECT_URL))
+
+        self.assertEqual(device.persistent_id,
+                         self.client.session.get(DEVICE_ID_SESSION_KEY))
+
+        # Check that the signal was fired.
+        mock_signal.assert_called_with(sender=mock.ANY, request=mock.ANY,
+                                       user=self.user, device=device)

--- a/tests/test_email.py
+++ b/tests/test_email.py
@@ -161,9 +161,10 @@ class EmailTest(UserMixin, TestCase):
                                     {'token-otp_token': 'a23456',
                                      'login_view-current_step': 'token'})
 
-        self.assertEqual(response.context_data['wizard']['form'].errors,
-                         {'__all__': ['Invalid token. Please make sure you '
-                                      'have entered it correctly.']})
+        self.assertEqual(
+            response.context_data['wizard']['form'].errors['otp_token'],
+            ['Enter a valid value.']
+        )
 
         token = re.findall(r'[0-9]{6}', msg.body)[0]
         response = self.client.post(reverse('two_factor:login'),

--- a/two_factor/apps.py
+++ b/two_factor/apps.py
@@ -1,5 +1,7 @@
-from django.apps import AppConfig
+from django.apps import AppConfig, apps
 from django.conf import settings
+
+from two_factor.plugins.registry import registry
 
 
 class TwoFactorConfig(AppConfig):
@@ -10,3 +12,6 @@ class TwoFactorConfig(AppConfig):
         if getattr(settings, 'TWO_FACTOR_PATCH_ADMIN', True):
             from .admin import patch_admin
             patch_admin()
+        if apps.is_installed('django_otp.plugins.otp_email'):
+            from two_factor.plugins.email.method import EmailMethod
+            registry.register(EmailMethod())

--- a/two_factor/apps.py
+++ b/two_factor/apps.py
@@ -1,7 +1,5 @@
-from django.apps import AppConfig, apps
+from django.apps import AppConfig
 from django.conf import settings
-
-from two_factor.plugins.registry import registry
 
 
 class TwoFactorConfig(AppConfig):
@@ -12,6 +10,3 @@ class TwoFactorConfig(AppConfig):
         if getattr(settings, 'TWO_FACTOR_PATCH_ADMIN', True):
             from .admin import patch_admin
             patch_admin()
-        if apps.is_installed('django_otp.plugins.otp_email'):
-            from two_factor.plugins.email.method import EmailMethod
-            registry.register(EmailMethod())

--- a/two_factor/forms.py
+++ b/two_factor/forms.py
@@ -132,6 +132,7 @@ class AuthenticationTokenForm(OTPAuthenticationFormMixin, forms.Form):
         """
         super().__init__(**kwargs)
         self.user = user
+        self.initial_device = initial_device
 
         # Add a field to remeber this browser.
         if getattr(settings, 'TWO_FACTOR_REMEMBER_COOKIE_AGE', None):

--- a/two_factor/plugins/email/__init__.py
+++ b/two_factor/plugins/email/__init__.py
@@ -1,0 +1,4 @@
+import django
+
+if django.VERSION <= (3, 2):
+    default_app_config = 'two_factor.plugins.email.apps.TwoFactorEmailConfig'

--- a/two_factor/plugins/email/apps.py
+++ b/two_factor/plugins/email/apps.py
@@ -1,0 +1,13 @@
+from django.apps import AppConfig
+
+from two_factor.plugins.registry import registry
+
+
+class TwoFactorEmailConfig(AppConfig):
+    name = 'two_factor.plugins.email'
+    verbose_name = "Django Two Factor Authentication – Email Method"
+
+    def ready(self):
+        from .method import EmailMethod
+
+        registry.register(EmailMethod())

--- a/two_factor/plugins/email/forms.py
+++ b/two_factor/plugins/email/forms.py
@@ -1,0 +1,31 @@
+from django import forms
+from django.utils.translation import gettext_lazy as _
+
+from two_factor.forms import (
+    AuthenticationTokenForm as BaseAuthenticationTokenForm,
+    DeviceValidationForm as BaseValidationForm,
+)
+
+
+class EmailForm(forms.Form):
+    email = forms.EmailField(label=_("Email address"))
+
+    def __init__(self, **kwargs):
+        kwargs.pop('device', None)
+        super().__init__(**kwargs)
+
+
+class DeviceValidationForm(BaseValidationForm):
+    token = forms.CharField(label=_("Token"))
+    token.widget.attrs.update({'autofocus': 'autofocus',
+                               'autocomplete': 'one-time-code'})
+    idempotent = False  # Once validated, the token is cleared.
+
+
+class AuthenticationTokenForm(BaseAuthenticationTokenForm):
+    otp_token = forms.CharField(label=_("Token"))
+    otp_token.widget.attrs.update({'autofocus': 'autofocus',
+                                   'autocomplete': 'one-time-code'})
+
+    def _chosen_device(self, user):
+        return self.initial_device

--- a/two_factor/plugins/email/forms.py
+++ b/two_factor/plugins/email/forms.py
@@ -23,9 +23,5 @@ class DeviceValidationForm(BaseValidationForm):
 
 
 class AuthenticationTokenForm(BaseAuthenticationTokenForm):
-    otp_token = forms.CharField(label=_("Token"))
-    otp_token.widget.attrs.update({'autofocus': 'autofocus',
-                                   'autocomplete': 'one-time-code'})
-
     def _chosen_device(self, user):
         return self.initial_device

--- a/two_factor/plugins/email/method.py
+++ b/two_factor/plugins/email/method.py
@@ -1,0 +1,33 @@
+from django.utils.translation import gettext_lazy as _
+from django_otp.plugins.otp_email.models import EmailDevice
+
+from two_factor.plugins.registry import MethodBase
+
+from .forms import AuthenticationTokenForm, DeviceValidationForm, EmailForm
+
+
+class EmailMethod(MethodBase):
+    code = 'email'
+    verbose_name = _('Email')
+
+    def recognize_device(self, device):
+        return isinstance(device, EmailDevice)
+
+    def get_setup_forms(self, wizard):
+        forms = {}
+        if not wizard.request.user.email:
+            forms[self.code] = EmailForm
+        forms['validation'] = DeviceValidationForm
+        return forms
+
+    def get_device_from_setup_data(self, request, setup_data, **kwargs):
+        if setup_data and not request.user.email:
+            request.user.email = setup_data.get('email').get('email')
+            request.user.save(update_fields=['email'])
+        device = EmailDevice.objects.devices_for_user(request.user).first()
+        if not device:
+            device = EmailDevice(user=request.user, name='default')
+        return device
+
+    def get_token_form_class(self):
+        return AuthenticationTokenForm

--- a/two_factor/plugins/phonenumber/method.py
+++ b/two_factor/plugins/phonenumber/method.py
@@ -10,7 +10,7 @@ class PhoneMethodBase(MethodBase):
     def recognize_device(self, device):
         return isinstance(device, PhoneDevice)
 
-    def get_setup_forms(self):
+    def get_setup_forms(self, *args):
         return {self.code: PhoneNumberForm}
 
     def get_device_from_setup_data(self, request, storage_data, **kwargs):

--- a/two_factor/plugins/registry.py
+++ b/two_factor/plugins/registry.py
@@ -12,7 +12,7 @@ class MethodBase:
         """
         return False
 
-    def get_setup_forms(self):
+    def get_setup_forms(self, wizard):
         """
         Return a dict where keys are setup wizard step names, and the values
         the form class matching the step.
@@ -39,7 +39,7 @@ class GeneratorMethod(MethodBase):
     verbose_name = _('Token generator')
     form_path = 'two_factor.forms.TOTPDeviceForm'
 
-    def get_setup_forms(self):
+    def get_setup_forms(self, *args):
         from two_factor.forms import TOTPDeviceForm
 
         return {'generator': TOTPDeviceForm}

--- a/two_factor/plugins/yubikey/method.py
+++ b/two_factor/plugins/yubikey/method.py
@@ -13,7 +13,7 @@ class YubikeyMethod(MethodBase):
     def recognize_device(self, device):
         return isinstance(device, RemoteYubikeyDevice)
 
-    def get_setup_forms(self):
+    def get_setup_forms(self, *args):
         return {'yubikey': YubiKeyDeviceForm}
 
     def get_device_from_setup_data(self, request, setup_data, **kwargs):

--- a/two_factor/views/core.py
+++ b/two_factor/views/core.py
@@ -293,7 +293,9 @@ class LoginView(SuccessURLAllowedHostsMixin, IdempotentSessionWizardView):
         either making a phone call or sending a text message.
         """
         if self.steps.current == 'token':
-            self.get_device().generate_challenge()
+            form_with_errors = form and form.is_bound and not form.is_valid()
+            if not form_with_errors:
+                self.get_device().generate_challenge()
         return super().render(form, **kwargs)
 
     def get_user(self):
@@ -442,10 +444,10 @@ class SetupView(IdempotentSessionWizardView):
             self.storage.validated_step_data['method'] = {'method': method_key}
         method = self.get_method()
         if method:
-            form_list.update(method.get_setup_forms())
+            form_list.update(method.get_setup_forms(self))
         else:
             for method in available_methods:
-                form_list.update(method.get_setup_forms())
+                form_list.update(method.get_setup_forms(self))
         if {'sms', 'call'} & set(form_list.keys()):
             form_list['validation'] = DeviceValidationForm
         return form_list
@@ -479,9 +481,8 @@ class SetupView(IdempotentSessionWizardView):
         if method.code == 'generator':
             form = [form for form in form_list if isinstance(form, TOTPDeviceForm)][0]
             device = form.save()
-
-        # PhoneNumberForm / YubiKeyDeviceForm
-        elif method.code in ('call', 'sms', 'yubikey'):
+        # PhoneNumberForm / YubiKeyDeviceForm / EmailForm
+        elif method.code in ('call', 'sms', 'yubikey', 'email'):
             device = self.get_device()
             device.save()
 


### PR DESCRIPTION
This is a follow-up pull request after #475, but based on the `EmailDevice` class from `django_otp`.

It also includes the commits from #476 and #477 (may be rebased when those are committed).