### PR TITLE
allow users to show the OTP secret key in text form during setup

### DIFF
--- a/docs/implementing.rst
+++ b/docs/implementing.rst
@@ -112,3 +112,11 @@ example to warn a user when one of his backup tokens was used::
                          'site_name': current_site.name}
             user.email_user(subject='Backup token used', message=message)
 
+
+Show OTP Secret Key During Setup
+--------------------------------
+
+Users who only have a smartphone will have difficulty scanning the QR code
+during setup. You can directly show the secret key within the QR code in text
+form during setup by providing your own ``two_factor/core/setup.html`` template
+and using the ``secret_key`` context variable.

--- a/tests/test_views_setup.py
+++ b/tests/test_views_setup.py
@@ -1,3 +1,4 @@
+from base64 import b32decode
 from binascii import unhexlify
 from unittest import mock
 
@@ -33,6 +34,10 @@ class SetupTest(UserMixin, TestCase):
         self.assertContains(response, 'autocomplete="one-time-code"')
         session = self.client.session
         self.assertIn('django_two_factor-qr_secret_key', session.keys())
+
+        # test if secret key is valid base32 and has the correct number of bytes
+        secret_key = response.context_data['secret_key']
+        self.assertEqual(len(b32decode(secret_key)), 20)
 
         response = self.client.post(
             reverse('two_factor:setup'),

--- a/two_factor/views/core.py
+++ b/two_factor/views/core.py
@@ -545,7 +545,8 @@ class SetupView(IdempotentSessionWizardView):
             b32key = b32encode(rawkey).decode('utf-8')
             self.request.session[self.session_key_name] = b32key
             context.update({
-                'QR_URL': reverse(self.qrcode_url)
+                'QR_URL': reverse(self.qrcode_url),
+                'secret_key': b32key,
             })
         elif self.steps.current == 'validation':
             context['device'] = self.get_device()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds the secret key in the form that can be manually input into authenticator apps to the setup context.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We have many users who only use smartphones, this allows them to setup 2FA on their smartphone device without having to scan a QR code.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added a test to check if it's in the context, if it's valid base32 and contains the correct number of bytes.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
