### PR TITLE
Remove a one-too-many dash from the parallel switch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ migrations:
 coverage:
 	coverage erase
 	DJANGO_SETTINGS_MODULE=tests.settings PYTHONPATH=. \
-		coverage run ---parallel --source=two_factor \
+		coverage run --parallel --source=two_factor \
 		`which django-admin` test ${TARGET}
 	coverage combine
 	coverage html


### PR DESCRIPTION
`---parallel` contains a dash too much, which results in `no such option: ---parallel`.

<!--- Provide a general summary of your changes in the Title above -->

## Description
Remove one dash, to make the `make coverage` work again.

## Motivation and Context
I tried to describe the motivation and context in this issue: https://github.com/jazzband/django-two-factor-auth/issues/496


## How Has This Been Tested?
Run `make coverage`

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
