### PR TITLE
feat: drop django 2.2, 3.0, and 3.1 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
+# Changelog
+
 ## Unreleased
 
 ### Added
 - Enforcing a redirect to setup of otp device when none available for user [#550](https://github.com/jazzband/django-two-factor-auth/pull/500)
+
+### Removed
+- Django 2.2, 3.0, and 3.1 support
 
 ## 1.14.0
 

--- a/README.rst
+++ b/README.rst
@@ -37,8 +37,8 @@ providing Django sessions with a foreign key to the user. Although the package
 is optional, it improves account security control over
 ``django.contrib.sessions``.
 
-Compatible with modern Django versions. At the moment of writing that's
-including 2.2, 3.1, 3.2, and 4.0 on Python 3.7, 3.8, 3.9 and 3.10.
+Compatible with supported Django and Python versions. At the moment of writing that
+includes 3.2 and 4.0 on Python 3.7, 3.8, 3.9 and 3.10.
 Documentation is available at `readthedocs.org`_.
 
 

--- a/docs/requirements.rst
+++ b/docs/requirements.rst
@@ -3,8 +3,7 @@ Requirements
 
 Django
 ------
-Modern Django versions are supported. Currently this list includes Django 2.2,
-3.0, 3.1, 3.2, and 4.0.
+Supported Django versions are supported. Currently this list includes Django 3.2, and 4.0.
 
 Python
 ------

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     license='MIT',
     packages=find_packages(exclude=('example', 'tests')),
     install_requires=[
-        'Django>=2.2',
+        'Django>=3.2',
         'django_otp>=0.8.0',
         'qrcode>=4.0.0,<7.99',
         'django-phonenumber-field>=1.1.0,<7',
@@ -30,9 +30,6 @@ setup(
         'Development Status :: 5 - Production/Stable',
         'Environment :: Web Environment',
         'Framework :: Django',
-        'Framework :: Django :: 2.2',
-        'Framework :: Django :: 3.0',
-        'Framework :: Django :: 3.1',
         'Framework :: Django :: 3.2',
         'Framework :: Django :: 4.0',
         'Intended Audience :: Developers',

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,6 @@
 ; Minimum version of Tox
 minversion = 1.8
 envlist =
-    py{37,38,39}-dj22-{normal,yubikey,custom_user},
-    py{37,38,39}-dj31-{normal,yubikey,custom_user},
     py{37,38,39,310}-dj32-{normal,yubikey,custom_user},
     py{38,39,310}-dj40-{normal,yubikey,custom_user}
     py{38,39,310}-djmain-{normal,yubikey,custom_user}
@@ -17,9 +15,6 @@ python =
 
 [gh-actions:env]
 DJANGO =
-    2.2: dj22
-    3.0: dj30
-    3.1: dj31
     3.2: dj32
     4.0: dj40
     main: djmain
@@ -39,8 +34,6 @@ basepython =
     py39: python3.9
     py310: python3.10
 deps =
-    dj22: Django<2.3
-    dj31: Django<3.2
     dj32: Django<4.0
     dj40: Django<4.1
     djmain: https://github.com/django/django/archive/main.tar.gz

--- a/two_factor/admin.py
+++ b/two_factor/admin.py
@@ -3,15 +3,9 @@ from django.contrib.admin import AdminSite
 from django.contrib.auth import REDIRECT_FIELD_NAME
 from django.contrib.auth.views import redirect_to_login
 from django.shortcuts import resolve_url
+from django.utils.http import url_has_allowed_host_and_scheme
 
 from .utils import monkeypatch_method
-
-try:
-    from django.utils.http import url_has_allowed_host_and_scheme
-except ImportError:
-    from django.utils.http import (
-        is_safe_url as url_has_allowed_host_and_scheme,
-    )
 
 
 class AdminSiteOTPRequiredMixin:

--- a/two_factor/views/core.py
+++ b/two_factor/views/core.py
@@ -20,6 +20,7 @@ from django.shortcuts import redirect, resolve_url
 from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.utils.functional import cached_property
+from django.utils.http import url_has_allowed_host_and_scheme
 from django.utils.module_loading import import_string
 from django.utils.translation import gettext as _
 from django.views.decorators.cache import never_cache
@@ -50,19 +51,11 @@ from .utils import (
 )
 
 try:
-    from django.utils.http import url_has_allowed_host_and_scheme
-except ImportError:  # django<3.0
-    from django.utils.http import (
-        is_safe_url as url_has_allowed_host_and_scheme,
-    )
-
-try:
     from django.contrib.auth.views import RedirectURLMixin
 except ImportError:  # django<4.1
     from django.contrib.auth.views import (
         SuccessURLAllowedHostsMixin as RedirectURLMixin,
     )
-
 logger = logging.getLogger(__name__)
 
 REMEMBER_COOKIE_PREFIX = getattr(settings, 'TWO_FACTOR_REMEMBER_COOKIE_PREFIX', 'remember-cookie_')


### PR DESCRIPTION
Drop support for EOL Django versions 2.2, 3.0, and 3.1

## Motivation and Context
As an open-source team, we don't have the resources to maintain compatibility with end-of-life code.  Consumers who need to work with older versions of Django can use older releases. 

## Checklist:
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.