### PR TITLE
Enforcing a redirect to setup of otp device when none available for user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+### Added
+- Enforcing a redirect to setup of otp device when none available for user [#550](https://github.com/jazzband/django-two-factor-auth/pull/500)
+
 ## 1.14.0
 
 ### Added

--- a/tests/test_views_login.py
+++ b/tests/test_views_login.py
@@ -38,7 +38,7 @@ class LoginTest(UserMixin, TestCase):
         response = self._post({'auth-username': 'bouke@example.com',
                                'auth-password': 'secret',
                                'login_view-current_step': 'auth'})
-        self.assertRedirects(response, resolve_url(settings.LOGIN_REDIRECT_URL))
+        self.assertRedirects(response, reverse('two_factor:setup'))
 
         # No signal should be fired for non-verified user logins.
         self.assertFalse(mock_signal.called)
@@ -80,7 +80,8 @@ class LoginTest(UserMixin, TestCase):
             {'auth-username': 'bouke@example.com',
              'auth-password': 'secret',
              'login_view-current_step': 'auth'})
-        self.assertRedirects(response, redirect_url, fetch_redirect_response=False)
+        self.assertEqual(self.client.session.get('next'), redirect_url)
+        self.assertRedirects(response, reverse('two_factor:setup'), fetch_redirect_response=False)
 
     def test_valid_login_with_disallowed_external_redirect(self):
         redirect_url = 'https://test.disallowed-success-url.com'
@@ -90,7 +91,7 @@ class LoginTest(UserMixin, TestCase):
             {'auth-username': 'bouke@example.com',
              'auth-password': 'secret',
              'login_view-current_step': 'auth'})
-        self.assertRedirects(response, reverse('two_factor:profile'), fetch_redirect_response=False)
+        self.assertRedirects(response, reverse('two_factor:setup'), fetch_redirect_response=False)
 
     @mock.patch('two_factor.views.core.time')
     def test_valid_login_primary_key_stored(self, mock_time):
@@ -395,12 +396,12 @@ class LoginTest(UserMixin, TestCase):
         response = self._post({'auth-username': 'bouke@example.com',
                                'auth-password': 'secret',
                                'login_view-current_step': 'auth'})
-        self.assertRedirects(response, resolve_url(settings.LOGIN_REDIRECT_URL))
+        self.assertRedirects(response, reverse('two_factor:setup'))
 
         response = self._post({'auth-username': 'vedran@example.com',
                                'auth-password': 'secret',
                                'login_view-current_step': 'auth'})
-        self.assertRedirects(response, resolve_url(settings.LOGIN_REDIRECT_URL))
+        self.assertRedirects(response, reverse('two_factor:setup'))
 
     def test_missing_management_data(self):
         # missing management data
@@ -431,8 +432,7 @@ class LoginTest(UserMixin, TestCase):
         response = self._post({'auth-username': 'bouke@example.com',
                                'auth-password': 'secret',
                                'login_view-current_step': 'auth'})
-        self.assertRedirects(response,
-                             resolve_url(settings.LOGIN_REDIRECT_URL))
+        self.assertRedirects(response, reverse('two_factor:setup'))
 
         response = self._post({'auth-username': 'vedran@example.com',
                                'auth-password': 'secret',

--- a/tests/test_views_mixins.py
+++ b/tests/test_views_mixins.py
@@ -1,8 +1,12 @@
+from binascii import unhexlify
+
 from django.conf import settings
 from django.shortcuts import resolve_url
 from django.test import TestCase
+from django.urls import reverse
+from django_otp.oath import totp
 
-from .utils import UserMixin
+from .utils import UserMixin, method_registry
 
 
 class OTPRequiredMixinTest(UserMixin, TestCase):
@@ -53,3 +57,50 @@ class OTPRequiredMixinTest(UserMixin, TestCase):
         self.login_user()
         response = self.client.get('/secure/')
         self.assertEqual(response.status_code, 200)
+
+    @method_registry(['generator'])
+    def test_valid_login_with_redirect_field_name_without_device(self):
+        self.create_user()
+        protected_url = '/secure/'
+
+        # Open URL that is protected
+        #  assert go to login page
+        #  assert the next param not in the session (but still in url)
+        response = self.client.get(protected_url)
+        redirect_url = "%s?%s%s" % (reverse('two_factor:login'), 'next=', protected_url)
+        self.assertRedirects(response, redirect_url)
+        self.assertEqual(self.client.session.get('next'), None)
+
+        # Log in given the last redirect
+        #  assert redirect to setup
+        response = self.client.post(
+            redirect_url,
+            {'auth-username': 'bouke@example.com',
+             'auth-password': 'secret',
+             'login_view-current_step': 'auth'})
+        self.assertRedirects(response, reverse('two_factor:setup'))
+        self.assertEqual(self.client.session.get('next'), protected_url)
+
+        # Setup the device accordingly
+        #  assert redirect to setup completed
+        #  assert button for redirection to the original page
+        response = self.client.post(
+            reverse('two_factor:setup'),
+            data={'setup_view-current_step': 'welcome'})
+        self.assertContains(response, 'Token:')
+        self.assertContains(response, 'autofocus="autofocus"')
+        self.assertContains(response, 'inputmode="numeric"')
+        self.assertContains(response, 'autocomplete="one-time-code"')
+
+        key = response.context_data['keys'].get('generator')
+        bin_key = unhexlify(key.encode())
+        response = self.client.post(
+            reverse('two_factor:setup'),
+            data={'setup_view-current_step': 'generator',
+                  'generator-token': totp(bin_key)},
+            follow=True,
+        )
+
+        self.assertRedirects(response, reverse('two_factor:setup_complete'))
+        self.assertContains(response, 'Continue where I left off')
+        self.assertContains(response, '<a href="%s' % protected_url)

--- a/tests/test_views_mixins.py
+++ b/tests/test_views_mixins.py
@@ -101,6 +101,4 @@ class OTPRequiredMixinTest(UserMixin, TestCase):
             follow=True,
         )
 
-        self.assertRedirects(response, reverse('two_factor:setup_complete'))
-        self.assertContains(response, 'Continue where I left off')
-        self.assertContains(response, '<a href="%s' % protected_url)
+        self.assertRedirects(response, protected_url)

--- a/two_factor/templates/two_factor/core/setup_complete.html
+++ b/two_factor/templates/two_factor/core/setup_complete.html
@@ -21,4 +21,8 @@
         class="btn btn-success">{% trans "Add Phone Number" %}</a></p>
   {% endif %}
 
+  {% if next %}
+    <a href="{{ next }}"
+       class="btn btn-block btn-success">{% trans "Continue where I left off" %}</a>
+  {% endif %}
 {% endblock %}

--- a/two_factor/templates/two_factor/core/setup_complete.html
+++ b/two_factor/templates/two_factor/core/setup_complete.html
@@ -21,8 +21,4 @@
         class="btn btn-success">{% trans "Add Phone Number" %}</a></p>
   {% endif %}
 
-  {% if next %}
-    <a href="{{ next }}"
-       class="btn btn-block btn-success">{% trans "Continue where I left off" %}</a>
-  {% endif %}
 {% endblock %}

--- a/two_factor/views/core.py
+++ b/two_factor/views/core.py
@@ -400,7 +400,7 @@ class LoginView(RedirectURLMixin, IdempotentSessionWizardView):
 
 @class_view_decorator(never_cache)
 @class_view_decorator(login_required)
-class SetupView(SuccessURLAllowedHostsMixin, IdempotentSessionWizardView):
+class SetupView(RedirectURLMixin, IdempotentSessionWizardView):
     """
     View for handling OTP setup using a wizard.
 

--- a/two_factor/views/core.py
+++ b/two_factor/views/core.py
@@ -182,7 +182,13 @@ class LoginView(RedirectURLMixin, IdempotentSessionWizardView):
                                     samesite=getattr(settings, 'TWO_FACTOR_REMEMBER_COOKIE_SAMESITE', 'Lax'),
                                     )
 
-        return response
+            return response
+
+        # If the user does not have a device.
+        else:
+            if self.request.GET.get('next'):
+                self.request.session['next'] = redirect_to
+            return redirect('two_factor:setup')
 
     # Copied from django.conrib.auth.views.LoginView (Branch: stable/1.11.x)
     # https://github.com/django/django/blob/58df8aa40fe88f753ba79e091a52f236246260b3/django/contrib/auth/views.py#L63
@@ -608,8 +614,10 @@ class SetupCompleteView(TemplateView):
     template_name = 'two_factor/core/setup_complete.html'
 
     def get_context_data(self):
+        redirect_url = self.request.session.pop('next', None)
         return {
             'phone_methods': get_available_phone_methods(),
+            'next': redirect_url
         }
 
 

--- a/two_factor/views/core.py
+++ b/two_factor/views/core.py
@@ -187,7 +187,7 @@ class LoginView(RedirectURLMixin, IdempotentSessionWizardView):
         # If the user does not have a device.
         else:
             if self.request.GET.get('next'):
-                self.request.session['next'] = redirect_to
+                self.request.session['next'] = self.get_success_url()
             return redirect('two_factor:setup')
 
     # Copied from django.conrib.auth.views.LoginView (Branch: stable/1.11.x)
@@ -400,7 +400,7 @@ class LoginView(RedirectURLMixin, IdempotentSessionWizardView):
 
 @class_view_decorator(never_cache)
 @class_view_decorator(login_required)
-class SetupView(IdempotentSessionWizardView):
+class SetupView(SuccessURLAllowedHostsMixin, IdempotentSessionWizardView):
     """
     View for handling OTP setup using a wizard.
 
@@ -423,6 +423,27 @@ class SetupView(IdempotentSessionWizardView):
         # Other forms are dynamically added in get_form_list()
     )
 
+    # Copied from django.conrib.auth.views.LoginView (Branch: stable/1.11.x)
+    # https://github.com/django/django/blob/58df8aa40fe88f753ba79e091a52f236246260b3/django/contrib/auth/views.py#L63
+    def get_success_url(self):
+        url = self.get_redirect_url()
+        return url or reverse('two_factor:setup_complete')
+
+    # Copied from django.conrib.auth.views.LoginView (Branch: stable/1.11.x)
+    # https://github.com/django/django/blob/58df8aa40fe88f753ba79e091a52f236246260b3/django/contrib/auth/views.py#L67
+    def get_redirect_url(self):
+        """Return the user-originating redirect URL if it's safe."""
+        redirect_to = self.request.POST.get(
+            REDIRECT_FIELD_NAME,
+            self.request.GET.get(REDIRECT_FIELD_NAME, '')
+        )
+        url_is_safe = url_has_allowed_host_and_scheme(
+            url=redirect_to,
+            allowed_hosts=self.get_success_url_allowed_hosts(),
+            require_https=self.request.is_secure(),
+        )
+        return redirect_to if url_is_safe else ''
+
     def get_method(self):
         method_data = self.storage.validated_step_data.get('method', {})
         method_key = method_data.get('method', None)
@@ -433,7 +454,7 @@ class SetupView(IdempotentSessionWizardView):
         Start the setup wizard. Redirect if already enabled.
         """
         if default_device(self.request.user):
-            return redirect(self.success_url)
+            return redirect(self.get_success_url())
         return super().get(request, *args, **kwargs)
 
     def get_form(self, step=None, **kwargs):
@@ -501,7 +522,7 @@ class SetupView(IdempotentSessionWizardView):
             raise NotImplementedError("Unknown method '%s'" % method.code)
 
         django_otp.login(self.request, device)
-        return redirect(self.success_url)
+        return redirect(self.get_success_url())
 
     def get_form_kwargs(self, step=None):
         kwargs = {}
@@ -613,11 +634,14 @@ class SetupCompleteView(TemplateView):
     """
     template_name = 'two_factor/core/setup_complete.html'
 
+    def get(self, request, *args, **kwargs):
+        if request.session.get('next'):
+            return redirect(request.session.get('next'))
+        return super().get(request, *args, **kwargs)
+
     def get_context_data(self):
-        redirect_url = self.request.session.pop('next', None)
         return {
             'phone_methods': get_available_phone_methods(),
-            'next': redirect_url
         }
 
 


### PR DESCRIPTION
This pull request will enforce a user, without OTP device, to be redirected to the OTP setup page keeping the redirected-from in mind.

## Description
Please refer to issue #499 for more details and context.

## Motivation and Context
Please refer to issue #499 for more details and context.


## How Has This Been Tested?
I created a scenario test: go to a protected page as anonymous user, log in, setup OTP and validate whether you get the option to be redirected to the page you meant to visit.
The current change has impact on the existing flow for users without OTP devices configured.

## Screenshots (if appropriate):
Currently I have not made any. I might be able to create a short movie about the workings.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
