### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -167,7 +167,7 @@ During a successful login with a token, the user may choose to remember this bro
 If the same user logs in again on the same browser, a token will not be requested, as the browser
 serves as a second factor.
 
-The option to remember a browser is deactived by default. Set `TWO_FACTOR_REMEMBER_COOKIE_AGE` to activate.
+The option to remember a browser is deactivated by default. Set `TWO_FACTOR_REMEMBER_COOKIE_AGE` to activate.
 
 The browser will be remembered as long as:
 
@@ -177,7 +177,7 @@ The browser will be remembered as long as:
 
 The browser is remembered by setting a signed 'remember cookie'.
 
-In order to invalidate remebered browsers after password resets,
+In order to invalidate remembered browsers after password resets,
 the package relies on the `password` field of the `User` model.
 Please consider this in case you do not use the `password` field
 e.g. [django-auth-ldap](https://github.com/django-auth-ldap/django-auth-ldap)

--- a/tests/test_views_login.py
+++ b/tests/test_views_login.py
@@ -661,7 +661,7 @@ class RememberLoginTest(UserMixin, TestCase):
 
         self.set_invalid_remember_cookie()
 
-        # Login but exired remember cookie
+        # Login but expire remember cookie
         response = self._post({'auth-username': 'bouke@example.com',
                                'auth-password': 'secret',
                                'login_view-current_step': 'auth'})

--- a/two_factor/views/core.py
+++ b/two_factor/views/core.py
@@ -183,13 +183,13 @@ class LoginView(RedirectURLMixin, IdempotentSessionWizardView):
                 self.request.session['next'] = self.get_success_url()
             return redirect('two_factor:setup')
 
-    # Copied from django.conrib.auth.views.LoginView (Branch: stable/1.11.x)
+    # Copied from django.contrib.auth.views.LoginView (Branch: stable/1.11.x)
     # https://github.com/django/django/blob/58df8aa40fe88f753ba79e091a52f236246260b3/django/contrib/auth/views.py#L63
     def get_success_url(self):
         url = self.get_redirect_url()
         return url or resolve_url(settings.LOGIN_REDIRECT_URL)
 
-    # Copied from django.conrib.auth.views.LoginView (Branch: stable/1.11.x)
+    # Copied from django.contrib.auth.views.LoginView (Branch: stable/1.11.x)
     # https://github.com/django/django/blob/58df8aa40fe88f753ba79e091a52f236246260b3/django/contrib/auth/views.py#L67
     def get_redirect_url(self):
         """Return the user-originating redirect URL if it's safe."""
@@ -374,7 +374,7 @@ class LoginView(RedirectURLMixin, IdempotentSessionWizardView):
             response.delete_cookie(cookie)
         return response
 
-    # Copied from django.conrib.auth.views.LoginView  (Branch: stable/1.11.x)
+    # Copied from django.contrib.auth.views.LoginView  (Branch: stable/1.11.x)
     # https://github.com/django/django/blob/58df8aa40fe88f753ba79e091a52f236246260b3/django/contrib/auth/views.py#L49
     @method_decorator(sensitive_post_parameters())
     @method_decorator(csrf_protect)
@@ -416,13 +416,13 @@ class SetupView(RedirectURLMixin, IdempotentSessionWizardView):
         # Other forms are dynamically added in get_form_list()
     )
 
-    # Copied from django.conrib.auth.views.LoginView (Branch: stable/1.11.x)
+    # Copied from django.contrib.auth.views.LoginView (Branch: stable/1.11.x)
     # https://github.com/django/django/blob/58df8aa40fe88f753ba79e091a52f236246260b3/django/contrib/auth/views.py#L63
     def get_success_url(self):
         url = self.get_redirect_url()
         return url or reverse('two_factor:setup_complete')
 
-    # Copied from django.conrib.auth.views.LoginView (Branch: stable/1.11.x)
+    # Copied from django.contrib.auth.views.LoginView (Branch: stable/1.11.x)
     # https://github.com/django/django/blob/58df8aa40fe88f753ba79e091a52f236246260b3/django/contrib/auth/views.py#L67
     def get_redirect_url(self):
         """Return the user-originating redirect URL if it's safe."""


### PR DESCRIPTION
There are small typos in:
- docs/configuration.rst
- tests/test_views_login.py
- two_factor/views/core.py

Fixes:
- Should read `contrib` rather than `conrib`.
- Should read `remembered` rather than `remebered`.
- Should read `expire` rather than `exired`.
- Should read `deactivated` rather than `deactived`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md