### PR TITLE
refactor: Move registry.get_methods() call to separate method, to all…

### DIFF
--- a/two_factor/views/core.py
+++ b/two_factor/views/core.py
@@ -480,7 +480,7 @@ class SetupView(RedirectURLMixin, IdempotentSessionWizardView):
         """
         form_list = super().get_form_list()
 
-        available_methods = registry.get_methods()
+        available_methods = self.get_available_methods()
         if len(available_methods) == 1:
             form_list.pop('method', None)
             method_key = available_methods[0].code
@@ -494,6 +494,9 @@ class SetupView(RedirectURLMixin, IdempotentSessionWizardView):
         if {'sms', 'call'} & set(form_list.keys()):
             form_list['validation'] = DeviceValidationForm
         return form_list
+
+    def get_available_methods(self):
+        return registry.get_methods()
 
     def render_next_step(self, form, **kwargs):
         """


### PR DESCRIPTION
…ow customization

Refs #533

## Description
This PR replaces direct call to `registry.get_methods()` with `self.get_available_methods()` in SetupView, to allow customization if methods available for setup depending on user.

## How Has This Been Tested?
This does not introduce any new behaviour, already covered by normal unit tests.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
