### PR TITLE
use assertEqual instead of deprecated assertEquals

### DIFF
--- a/two_factor/plugins/webauthn/tests/test_forms.py
+++ b/two_factor/plugins/webauthn/tests/test_forms.py
@@ -30,7 +30,7 @@ class WebauthnAuthenticationFormTests(TestCase):
         with self.assertRaises(ValidationError) as context:
             form._verify_token(None, 'invalid-token')
 
-        self.assertEquals(context.exception.code, 'invalid_token')
+        self.assertEqual(context.exception.code, 'invalid_token')
 
 
 @skipUnless(webauthn, 'package webauthn is not present')
@@ -44,4 +44,4 @@ class WebauthnDeviceValidationFormTests(TestCase):
         form = WebauthnDeviceValidationForm(None, request, data=data)
 
         self.assertFalse(form.is_valid())
-        self.assertEquals(form.error_messages.keys(), {'invalid_token'})
+        self.assertEqual(form.error_messages.keys(), {'invalid_token'})

--- a/two_factor/plugins/webauthn/tests/test_utils.py
+++ b/two_factor/plugins/webauthn/tests/test_utils.py
@@ -33,29 +33,29 @@ class UtilsTests(TestCase):
             self.mocked_user, self.mocked_rp, [self.mocked_credential_id_b64], challenge=self.mocked_challenge)
         options = json.loads(json_options)
 
-        self.assertEquals(options['rp'], {'id': self.mocked_rp.id, 'name': self.mocked_rp.name})
-        self.assertEquals(
+        self.assertEqual(options['rp'], {'id': self.mocked_rp.id, 'name': self.mocked_rp.name})
+        self.assertEqual(
             options['user'],
             {'id': self.mocked_user_id_b64, 'name': 'mocked-username', 'displayName': 'Mocked Display Name'},
         )
-        self.assertEquals(options['challenge'], self.mocked_challenge)
-        self.assertEquals(options['excludeCredentials'], [{'type': 'public-key', 'id': self.mocked_credential_id_b64}])
-        self.assertEquals(
+        self.assertEqual(options['challenge'], self.mocked_challenge)
+        self.assertEqual(options['excludeCredentials'], [{'type': 'public-key', 'id': self.mocked_credential_id_b64}])
+        self.assertEqual(
             options['authenticatorSelection'],
             {'requireResidentKey': False, 'userVerification': 'discouraged'},
         )
-        self.assertEquals(options['attestation'], 'none')
-        self.assertEquals(challenge_b64, self.mocked_challenge)
+        self.assertEqual(options['attestation'], 'none')
+        self.assertEqual(challenge_b64, self.mocked_challenge)
 
     def test_make_credential_request_options(self):
         json_options, challenge_b64 = make_credential_request_options(
             self.mocked_rp, [self.mocked_credential_id_b64], challenge=self.mocked_challenge)
         options = json.loads(json_options)
 
-        self.assertEquals(options['rpId'], self.mocked_rp.id)
-        self.assertEquals(options['challenge'], self.mocked_challenge)
-        self.assertEquals(len(options['allowCredentials']), 1)
-        self.assertEquals(options['allowCredentials'][0]['type'], 'public-key')
-        self.assertEquals(options['allowCredentials'][0]['id'], self.mocked_credential_id_b64)
-        self.assertEquals(options['userVerification'], 'discouraged')
-        self.assertEquals(challenge_b64, self.mocked_challenge)
+        self.assertEqual(options['rpId'], self.mocked_rp.id)
+        self.assertEqual(options['challenge'], self.mocked_challenge)
+        self.assertEqual(len(options['allowCredentials']), 1)
+        self.assertEqual(options['allowCredentials'][0]['type'], 'public-key')
+        self.assertEqual(options['allowCredentials'][0]['id'], self.mocked_credential_id_b64)
+        self.assertEqual(options['userVerification'], 'discouraged')
+        self.assertEqual(challenge_b64, self.mocked_challenge)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
