### PR TITLE
Call explicit form rendering methods to avoid warnings

### DIFF
--- a/example/templates/registration.html
+++ b/example/templates/registration.html
@@ -6,7 +6,7 @@
 
   <form action="" method="POST">
     {% csrf_token %}
-    <table>{{ form }}</table>
+    <table>{{ form.as_table }}</table>
     <button class="btn btn-primary" type="submit">{% trans "Register" %}</button>
   </form>
 {% endblock %}

--- a/two_factor/templates/two_factor/_wizard_forms.html
+++ b/two_factor/templates/two_factor/_wizard_forms.html
@@ -1,4 +1,4 @@
 <table class="mb-3">
   {{ wizard.management_form }}
-  {{ wizard.form }}
+  {{ wizard.form.as_table }}
 </table>

--- a/two_factor/templates/two_factor/core/backup_tokens.html
+++ b/two_factor/templates/two_factor/core/backup_tokens.html
@@ -20,7 +20,7 @@
     <p>{% trans "You don't have any backup codes yet." %}</p>
   {% endif %}
 
-  <form method="post">{% csrf_token %}{{ form }}
+  <form method="post">{% csrf_token %}{{ form.as_p }}
     <a href="{% url 'two_factor:profile'%}"
        class="float-right btn btn-link">{% trans "Back to Account Security" %}</a>
     <button class="btn btn-primary" type="submit">{% trans "Generate Tokens" %}</button>

--- a/two_factor/templates/two_factor/profile/disable.html
+++ b/two_factor/templates/two_factor/profile/disable.html
@@ -7,7 +7,7 @@
     weakens your account security, are you sure?{% endblocktrans %}</p>
   <form method="post">
     {% csrf_token %}
-    <table>{{ form }}</table>
+    <table>{{ form.as_table }}</table>
     <button class="btn btn-danger"
             type="submit">{% trans "Disable" %}</button>
   </form>


### PR DESCRIPTION
Starting from Django 4.1, default rendering of `{{ form }}` produces deprecation warnings. This should avoid those produced by d2fa own templates.