### PR TITLE
fix regression from PR #500

### DIFF
--- a/tests/test_views_login.py
+++ b/tests/test_views_login.py
@@ -38,13 +38,23 @@ class LoginTest(UserMixin, TestCase):
         response = self._post({'auth-username': 'bouke@example.com',
                                'auth-password': 'secret',
                                'login_view-current_step': 'auth'})
-        self.assertRedirects(response, reverse('two_factor:setup'))
+        self.assertRedirects(response, resolve_url(settings.LOGIN_REDIRECT_URL))
 
         # No signal should be fired for non-verified user logins.
         self.assertFalse(mock_signal.called)
 
     def test_valid_login_with_custom_redirect(self):
         redirect_url = reverse('two_factor:setup')
+        self.create_user()
+        response = self.client.post(
+            '%s?%s' % (reverse('two_factor:login'), 'next=' + redirect_url),
+            {'auth-username': 'bouke@example.com',
+             'auth-password': 'secret',
+             'login_view-current_step': 'auth'})
+        self.assertRedirects(response, redirect_url)
+
+    def test_valid_login_non_class_based_redirect(self):
+        redirect_url = reverse('plain')
         self.create_user()
         response = self.client.post(
             '%s?%s' % (reverse('two_factor:login'), 'next=' + redirect_url),
@@ -80,8 +90,7 @@ class LoginTest(UserMixin, TestCase):
             {'auth-username': 'bouke@example.com',
              'auth-password': 'secret',
              'login_view-current_step': 'auth'})
-        self.assertEqual(self.client.session.get('next'), redirect_url)
-        self.assertRedirects(response, reverse('two_factor:setup'), fetch_redirect_response=False)
+        self.assertRedirects(response, redirect_url, fetch_redirect_response=False)
 
     def test_valid_login_with_disallowed_external_redirect(self):
         redirect_url = 'https://test.disallowed-success-url.com'
@@ -91,7 +100,7 @@ class LoginTest(UserMixin, TestCase):
             {'auth-username': 'bouke@example.com',
              'auth-password': 'secret',
              'login_view-current_step': 'auth'})
-        self.assertRedirects(response, reverse('two_factor:setup'), fetch_redirect_response=False)
+        self.assertRedirects(response, reverse('two_factor:profile'), fetch_redirect_response=False)
 
     @mock.patch('two_factor.views.core.time')
     def test_valid_login_primary_key_stored(self, mock_time):
@@ -396,12 +405,12 @@ class LoginTest(UserMixin, TestCase):
         response = self._post({'auth-username': 'bouke@example.com',
                                'auth-password': 'secret',
                                'login_view-current_step': 'auth'})
-        self.assertRedirects(response, reverse('two_factor:setup'))
+        self.assertRedirects(response, resolve_url(settings.LOGIN_REDIRECT_URL))
 
         response = self._post({'auth-username': 'vedran@example.com',
                                'auth-password': 'secret',
                                'login_view-current_step': 'auth'})
-        self.assertRedirects(response, reverse('two_factor:setup'))
+        self.assertRedirects(response, resolve_url(settings.LOGIN_REDIRECT_URL))
 
     def test_missing_management_data(self):
         # missing management data
@@ -432,7 +441,7 @@ class LoginTest(UserMixin, TestCase):
         response = self._post({'auth-username': 'bouke@example.com',
                                'auth-password': 'secret',
                                'login_view-current_step': 'auth'})
-        self.assertRedirects(response, reverse('two_factor:setup'))
+        self.assertRedirects(response, resolve_url(settings.LOGIN_REDIRECT_URL))
 
         response = self._post({'auth-username': 'vedran@example.com',
                                'auth-password': 'secret',

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -5,7 +5,7 @@ from two_factor.gateways.twilio.urls import urlpatterns as tf_twilio_urls
 from two_factor.urls import urlpatterns as tf_urls
 from two_factor.views import LoginView
 
-from .views import SecureView
+from .views import SecureView, plain_view
 
 urlpatterns = [
     path(
@@ -38,6 +38,11 @@ urlpatterns = [
         name='custom-redirect-authenticated-user-login',
     ),
 
+    path(
+        'plain/',
+        plain_view,
+        name="plain",
+    ),
     path(
         'secure/',
         SecureView.as_view(),

--- a/tests/views.py
+++ b/tests/views.py
@@ -1,3 +1,4 @@
+from django.http import HttpResponse
 from django.views.generic import TemplateView
 
 from two_factor.views import OTPRequiredMixin
@@ -5,3 +6,8 @@ from two_factor.views import OTPRequiredMixin
 
 class SecureView(OTPRequiredMixin, TemplateView):
     template_name = 'secure.html'
+
+
+def plain_view(request):
+    """ Non-class based view """
+    return HttpResponse('plain')

--- a/two_factor/views/core.py
+++ b/two_factor/views/core.py
@@ -38,6 +38,7 @@ from two_factor import signals
 from two_factor.plugins.phonenumber.utils import get_available_phone_methods
 from two_factor.plugins.registry import registry
 from two_factor.utils import totp_digits
+from two_factor.views.mixins import OTPRequiredMixin
 
 from ..forms import (
     AuthenticationTokenForm, BackupTokenForm, DeviceValidationForm, MethodForm,
@@ -174,16 +175,17 @@ class LoginView(RedirectURLMixin, IdempotentSessionWizardView):
                                     httponly=getattr(settings, 'TWO_FACTOR_REMEMBER_COOKIE_HTTPONLY', True),
                                     samesite=getattr(settings, 'TWO_FACTOR_REMEMBER_COOKIE_SAMESITE', 'Lax'),
                                     )
-
             return response
 
         # If the user does not have a device.
-        else:
+        elif OTPRequiredMixin.is_otp_view(self.request.GET.get('next')):
             if self.request.GET.get('next'):
                 self.request.session['next'] = self.get_success_url()
             return redirect('two_factor:setup')
 
-    # Copied from django.contrib.auth.views.LoginView (Branch: stable/1.11.x)
+        return response
+
+    # Copied from django.conrib.auth.views.LoginView (Branch: stable/1.11.x)
     # https://github.com/django/django/blob/58df8aa40fe88f753ba79e091a52f236246260b3/django/contrib/auth/views.py#L63
     def get_success_url(self):
         url = self.get_redirect_url()

--- a/two_factor/views/mixins.py
+++ b/two_factor/views/mixins.py
@@ -2,7 +2,7 @@ from django.contrib.auth import REDIRECT_FIELD_NAME
 from django.contrib.auth.views import redirect_to_login
 from django.core.exceptions import PermissionDenied
 from django.template.response import TemplateResponse
-from django.urls import reverse
+from django.urls import Resolver404, resolve, reverse
 
 from ..utils import default_device
 
@@ -80,3 +80,14 @@ class OTPRequiredMixin:
                     status=403,
                 )
         return super().dispatch(request, *args, **kwargs)
+
+    @classmethod
+    def is_otp_view(cls, view_path):
+        try:
+            next_resolver_match = resolve(view_path)
+        except Resolver404:
+            return False
+        return (
+            hasattr(next_resolver_match.func, 'view_class') and
+            issubclass(next_resolver_match.func.view_class, OTPRequiredMixin)
+        )


### PR DESCRIPTION
Fix regression introduced in #500.


## Description
All the changes of `test_view_login.py` were wrong and they are reverted. 
We are now detecting if OTPRequiredMixin is used for `next` URL and only then we redirect to OTP setup page.
The newly introduced test in OTPRequiredMixinTest is not changed and passes.

## Motivation and Context
Fix regression described in #499

## How Has This Been Tested?
- TOX tests
- tests of Login view on my own project that were not passing after #500

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
