### PR TITLE
Modularise parts of the `LoginView`

### DIFF
--- a/two_factor/views/core.py
+++ b/two_factor/views/core.py
@@ -130,7 +130,7 @@ class LoginView(RedirectURLMixin, IdempotentSessionWizardView):
         if wizard_goto_step == self.FIRST_STEP:
             self.storage.reset()
 
-        if self.expired and self.steps.current != self.FIRST_STEP:
+        if self.expired and self.step_requires_authentication(self.steps.current):
             logger.info("User's authentication flow has timed out. The user "
                         "has been redirected to the initial auth form.")
             self.storage.reset()
@@ -321,6 +321,9 @@ class LoginView(RedirectURLMixin, IdempotentSessionWizardView):
             other_devices += list(method.get_other_authentication_devices(user, main_device))
 
         return other_devices
+
+    def step_requires_authentication(self, step):
+        return step != self.FIRST_STEP
 
     def render(self, form=None, **kwargs):
         """


### PR DESCRIPTION
## Description
I modularized parts of the `LoginView`, as far as I can tell without modifying existing behavior, but providing more hooks to custromize the `LoginView` via inheritance.

Notice how I split the constants defining the steps into `AUTH_STEP` and `FIRST_STEP`. I assume the clearing of the state in `post()` is meant to happen at the first step of the wizard, which does not necessarily have to be the `'auth'` step.

## Motivation and Context
We use a custom version of the `LoginView` that adds an additional step in the login flow before the actual `'auth'` step. At the moment this requires duplicating large amounts of code. By merging this change it would become a lot easier to accommodate such customization without large changes.

## How Has This Been Tested?
We are currently integrating my fork and it allows large parts of the customization we require. 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
