### PR TITLE
Add Python 3.11 to CI, tox, and trove classifiers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
     env:
       COVERAGE_OPTIONS: "-a"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Enforcing a redirect to setup of otp device when none available for user [#550](https://github.com/jazzband/django-two-factor-auth/pull/500)
 - Confirmed Django 4.1 support
 - WebAuthn support
+- Python 3.11 support
 
 ### Removed
 - Django 2.2, 3.0, and 3.1 support

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Enforcing a redirect to setup of otp device when none available for user [#550](https://github.com/jazzband/django-two-factor-auth/pull/500)
 - Confirmed Django 4.1 support
 - WebAuthn support
-- Python 3.11 support
+- Confirmed Python 3.11 support
 
 ### Removed
 - Django 2.2, 3.0, and 3.1 support

--- a/docs/requirements.rst
+++ b/docs/requirements.rst
@@ -7,7 +7,7 @@ Supported Django versions are supported. Currently this list includes Django 3.2
 
 Python
 ------
-The following Python versions are supported: 3.7, 3.8, 3.9 and 3.10 with a
+The following Python versions are supported: 3.7, 3.8, 3.9, 3.10 and 3.11 with a
 limit to what Django itself supports. As support for older Django versions is
 dropped, the minimum version might be raised. See also `What Python version can
 I use with Django?`_.

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup(
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
         'Topic :: Security',
         'Topic :: System :: Systems Administration :: Authentication/Directory',
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -2,9 +2,9 @@
 ; Minimum version of Tox
 minversion = 1.8
 envlist =
-    py{37,38,39,310}-dj32-{normal,yubikey,custom_user,webauthn}
-    py{38,39,310}-dj{40,41}-{normal,yubikey,custom_user,webauthn}
-    py{38,39,310}-djmain-{normal,yubikey,custom_user,webauthn}
+    py{37,38,39,310,311}-dj32-{normal,yubikey,custom_user,webauthn}
+    py{38,39,310,311}-dj{40,41}-{normal,yubikey,custom_user,webauthn}
+    py{38,39,310,311}-djmain-{normal,yubikey,custom_user,webauthn}
 
 [gh-actions]
 python =
@@ -12,6 +12,7 @@ python =
     3.8: py38
     3.9: py39
     3.10: py310
+    3.11: py311
 
 [gh-actions:env]
 DJANGO =
@@ -36,6 +37,7 @@ basepython =
     py38: python3.8
     py39: python3.9
     py310: python3.10
+    py311: python3.11
 deps =
     dj32: Django<4.0
     dj40: Django<4.1


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds Python 3.11 to GHA `build.yml` workflow, `tox.ini`, and the list of trove classifiers in `setup.py`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Python 3.11 was released this week.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
In CI on my fork.

## Screenshots (if appropriate):
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
