### PR TITLE
Use configured success_url

### DIFF
--- a/tests/urls.py
+++ b/tests/urls.py
@@ -3,7 +3,7 @@ from django.urls import include, path
 
 from two_factor.gateways.twilio.urls import urlpatterns as tf_twilio_urls
 from two_factor.urls import urlpatterns as tf_urls
-from two_factor.views import LoginView
+from two_factor.views import LoginView, SetupView
 
 from .views import SecureView, plain_view
 
@@ -37,7 +37,11 @@ urlpatterns = [
         ),
         name='custom-redirect-authenticated-user-login',
     ),
-
+    path(
+        'account/setup-backup-tokens-redirect/',
+        SetupView.as_view(success_url='two_factor:backup_tokens'),
+        name='setup-backup_tokens-redirect'
+    ),
     path(
         'plain/',
         plain_view,

--- a/two_factor/views/core.py
+++ b/two_factor/views/core.py
@@ -446,7 +446,7 @@ class SetupView(RedirectURLMixin, IdempotentSessionWizardView):
     # https://github.com/django/django/blob/58df8aa40fe88f753ba79e091a52f236246260b3/django/contrib/auth/views.py#L63
     def get_success_url(self):
         url = self.get_redirect_url()
-        return url or reverse('two_factor:setup_complete')
+        return url or reverse(self.success_url)
 
     # Copied from django.contrib.auth.views.LoginView (Branch: stable/1.11.x)
     # https://github.com/django/django/blob/58df8aa40fe88f753ba79e091a52f236246260b3/django/contrib/auth/views.py#L67


### PR DESCRIPTION
## Description

Restore the ability to override the success_url in urls.py (it was added in 3d0d92fe5ed4bf381628e24a15d040f0db3cff2d)

## Motivation and Context

We use a simple subclass to redirect the users to the backup token screen once setup is completed

```
class TwoFactorSetupView(SetupView):
    # Redirect to the "backup tokens" instead of the "setup complete" screen
    success_url = "two_factor:backup_tokens"
```

I believe this doesn't work anymore after a (recent) change to `SetupView`.

## How Has This Been Tested?

I have not tested this, I was just reading the code when I noticed this change.

## Screenshots (if appropriate):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
