### PR TITLE
Exclude webdriver-manager 3.8.5 when installing e2e requirements

### DIFF
--- a/requirements_e2e.txt
+++ b/requirements_e2e.txt
@@ -1,3 +1,3 @@
 # test with selenium
 selenium~=4.4.3
-webdriver-manager~=3.8.3
+webdriver-manager~=3.8.3,!=3.8.5

--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,9 @@ VARIANT =
     custom_user: custom_user
 
 [testenv]
-passenv = HOME DISPLAY
+passenv =
+    HOME
+    DISPLAY
 setenv =
     PYTHONDONTWRITEBYTECODE=1
     PYTHONWARNINGS=always


### PR DESCRIPTION
That version appears to break things

<!--- Provide a general summary of your changes in the Title above -->

## Description
Excludes webdriver-manager 3.8.5 from being installed

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Tests have been broken ever since webdriver-manager 3.8.5 was released. Nothing appears to be broken in django-two-factor-auth. Hopefully this issue will be fixed in a future version of webdriver-manager which is why I am only excluding that one version.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran tests webauthn tests under Python 3.11 locally and saw that tests passed

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
