### PR TITLE
Upgrade isort and flake8 in pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 repos:
   - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
     - id: isort
       args: ['--check-only', '--diff']
 
   - repo: https://github.com/PyCQA/flake8
-    rev: 5.0.4
+    rev: 6.0.0
     hooks:
       - id: flake8
         files: ^(example|tests|two_factor)/


### PR DESCRIPTION
Fix failing of pre-commit ci

## Description
I think the failure was because of an issue in `isort` https://github.com/PyCQA/isort/pull/2078
So I upgrade it to `5.12.0`
I also upgraded the flake8 to  `6.0.0`
