### PR TITLE
Remove backported salted_hmac use django provided one instead

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -16,8 +16,7 @@ from two_factor.utils import (
     totp_digits,
 )
 from two_factor.views.utils import (
-    get_remember_device_cookie, salted_hmac_sha256,
-    validate_remember_device_cookie,
+    get_remember_device_cookie, validate_remember_device_cookie,
 )
 
 from .utils import UserMixin
@@ -135,11 +134,6 @@ class UtilsTest(UserMixin, TestCase):
             otp_device_id="SomeModel/34",
         )
         self.assertFalse(validation_result)
-
-    def test_salted_hmac_sha256(self):
-        hmac_with_secret = salted_hmac_sha256("blah", "blah", "my-new-secret")
-        hmac_without_secret = salted_hmac_sha256("blah", "blah")
-        self.assertNotEqual(hmac_with_secret, hmac_without_secret)
 
 
 class PhoneUtilsTests(UserMixin, TestCase):

--- a/two_factor/views/utils.py
+++ b/two_factor/views/utils.py
@@ -1,6 +1,4 @@
 import base64
-import hashlib
-import hmac
 import logging
 import time
 
@@ -8,6 +6,7 @@ from django.conf import settings
 from django.contrib.auth import load_backend
 from django.core.exceptions import SuspiciousOperation
 from django.core.signing import BadSignature, SignatureExpired
+from django.utils.crypto import salted_hmac
 from django.utils.decorators import method_decorator
 from django.utils.encoding import force_bytes
 from django.utils.translation import gettext as _
@@ -297,14 +296,4 @@ def hash_remember_device_cookie_key(otp_device_id):
 def hash_remember_device_cookie_value(otp_device_id, user, timestamp):
     salt = 'two_factor.views.utils.hash_remember_device_cookie_value'
     value = otp_device_id + str(user.pk) + str(user.password) + timestamp
-    return salted_hmac_sha256(salt, value).hexdigest()
-
-
-# inspired by django.utils.crypto.salted_hmac django versions > 3.1a1
-def salted_hmac_sha256(key_salt, value, secret=None):
-    if secret is None:
-        secret = settings.SECRET_KEY
-    key_salt = force_bytes(key_salt)
-    secret = force_bytes(secret)
-    key = hashlib.sha256(key_salt + secret).digest()
-    return hmac.new(key, msg=force_bytes(value), digestmod=hashlib.sha256)
+    return salted_hmac(salt, value, algorithm='sha256').hexdigest()


### PR DESCRIPTION
## Description
Removes  `salted_hmac_256` from the codebase, replacing with `django.utils.crypto.salted_hmac`.

Also a small tweak: using `tuple` instead of `list` when there is no need to modify a sequence which is only needed to match an array-like API.

## Motivation and Context
As stated in #601: this package now has a minimum requirements for `django>=3.2`, thus the backported method `salted_hmac_256` is not required anymore as we can rely on `salted_hmac` from django.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue), refactor
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
