### PR TITLE
Fixes #611 - Create custom CreatePhoneDevice migration operation

### DIFF
--- a/two_factor/plugins/phonenumber/migrations/0001_squashed_0001_initial.py
+++ b/two_factor/plugins/phonenumber/migrations/0001_squashed_0001_initial.py
@@ -2,13 +2,78 @@ import django_otp.util
 import phonenumber_field.modelfields
 from django.conf import settings
 from django.db import migrations, models
+from django.db.migrations.operations.base import Operation
 
 import two_factor.plugins.phonenumber.models
+
+
+class CreatePhoneDevice(Operation):
+    """This fixes the problem described in
+    https://github.com/jazzband/django-two-factor-auth/issues/611
+
+    The problem was that the database can be in two different states when this
+    migration is run. The first state is when we upgrade from an older version
+    that has the two_factor_phonedevice already created by the two-factor app.
+    In this case we should not create the two_factor_phonedevice database table.
+    The second state is when the old two-factor migrations haven't been run and
+    we need to create the table.
+
+    Using this custom operation we check whether the table exists before
+    creating it.
+    """
+
+    reversible = False
+    create_model_operation = migrations.CreateModel(
+        name='PhoneDevice',
+        fields=[
+            ('id',
+             models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+            ('name', models.CharField(help_text='The human-readable name of this device.', max_length=64)),
+            ('confirmed', models.BooleanField(default=True, help_text='Is this device ready for use?')),
+            ('throttling_failure_timestamp', models.DateTimeField(
+                blank=True, default=None,
+                help_text='A timestamp of the last failed verification attempt. '
+                'Null if last attempt succeeded.',
+                null=True)),
+            ('throttling_failure_count',
+             models.PositiveIntegerField(default=0, help_text='Number of successive failed attempts.')),
+            ('number', phonenumber_field.modelfields.PhoneNumberField(max_length=128, region=None)),
+            ('key', models.CharField(default=django_otp.util.random_hex,
+                                     help_text='Hex-encoded secret key',
+                                     max_length=40,
+                                     validators=[two_factor.plugins.phonenumber.models.key_validator])),
+            ('method',
+             models.CharField(choices=[('call', 'Phone Call'), ('sms', 'Text Message')], max_length=4,
+                              verbose_name='method')),
+            ('user', models.ForeignKey(help_text='The user that this device belongs to.',
+                                       on_delete=models.deletion.CASCADE,
+                                       to=settings.AUTH_USER_MODEL)),
+        ],
+        options={
+            'db_table': 'two_factor_phonedevice',
+        },
+    )
+
+    def state_forwards(self, app_label, state):
+        self.create_model_operation.state_forwards(app_label, state)
+
+    def database_forwards(self, app_label, schema_editor, from_state, to_state):
+        if "two_factor_phonedevice" not in schema_editor.connection.introspection.table_names():
+            # The table doesn't exist. This means we aren't upgrading from a
+            # previous version where the two_factor app created the table and
+            # need to create the table.
+            to_state = from_state.clone()
+            self.create_model_operation.state_forwards(app_label, to_state)
+            self.create_model_operation.database_forwards(app_label, schema_editor, from_state, to_state)
+
+    def describe(self):
+        return "Create PhoneDevice"
 
 
 class Migration(migrations.Migration):
     replaces = [
         ('phonenumber', '0001_initial'),
+        ('twofactor', '0001_squashed_0008_delete_phonedevice'),
     ]
 
     initial = True
@@ -18,34 +83,5 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.CreateModel(
-            name='PhoneDevice',
-            fields=[
-                ('id',
-                 models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('name', models.CharField(help_text='The human-readable name of this device.', max_length=64)),
-                ('confirmed', models.BooleanField(default=True, help_text='Is this device ready for use?')),
-                ('throttling_failure_timestamp', models.DateTimeField(
-                    blank=True, default=None,
-                    help_text='A timestamp of the last failed verification attempt. '
-                              'Null if last attempt succeeded.',
-                    null=True)),
-                ('throttling_failure_count',
-                 models.PositiveIntegerField(default=0, help_text='Number of successive failed attempts.')),
-                ('number', phonenumber_field.modelfields.PhoneNumberField(max_length=128, region=None)),
-                ('key', models.CharField(default=django_otp.util.random_hex,
-                                         help_text='Hex-encoded secret key',
-                                         max_length=40,
-                                         validators=[two_factor.plugins.phonenumber.models.key_validator])),
-                ('method',
-                 models.CharField(choices=[('call', 'Phone Call'), ('sms', 'Text Message')], max_length=4,
-                                  verbose_name='method')),
-                ('user', models.ForeignKey(help_text='The user that this device belongs to.',
-                                           on_delete=models.deletion.CASCADE,
-                                           to=settings.AUTH_USER_MODEL)),
-            ],
-            options={
-                'db_table': 'two_factor_phonedevice',
-            },
-        ),
+        CreatePhoneDevice(),
     ]


### PR DESCRIPTION
## Description
Upgrading didn't work anymore because the phonenumber plugin migration would try to create the two_factor_phonedevice that already exists. This fixes upgrading by creating the model using a custom operation that first checks if the two_factor_phonedevice table already exists before creating the table.

## Motivation and Context
Fixes #611

## How Has This Been Tested?
I have created a test Django app and installed the two-factor-auth app. First I installed 1.13.1, ran the migrations, then upgraded to this code and ran the migrations. I then deleted and recreated the database and ran migrations again. I used `pg_dump --schema-only` to verify that the migrations had the same end result and also compared it with 1.15.2.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
