### PR TITLE
Exclude also tests submodules

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     url='https://github.com/jazzband/django-two-factor-auth',
     download_url='https://pypi.python.org/project/django-two-factor-auth',
     license='MIT',
-    packages=find_packages(exclude=('example', 'tests')),
+    packages=find_packages(exclude=('example', 'tests', 'tests.*')),
     install_requires=[
         'Django>=3.2',
         'django_otp>=0.8.0',


### PR DESCRIPTION
## Description

It is necessary to extend exclude list with `tests.*` pattern, otherwise tests submodules will be installed as well. For reference, see custom discovery in setuptools documentation [1].

[1] https://setuptools.pypa.io/en/latest/userguide/package_discovery.html#custom-discovery

## Motivation and Context

Gentoo package manager refuses to install the package with following error:
```
* Messages for package dev-python/django-two-factor-auth-1.15.2:

 * The following unexpected files/directories were found top-level
 * in the site-packages directory:
 * 
 *   /usr/lib/python3.11/site-packages/tests
 * 
 * This is most likely a bug in the build system.  More information
 * can be found in the Python Guide:
 * https://projects.gentoo.org/python/guide/qawarn.html#stray-top-level-files-in-site-packages
 * ERROR: dev-python/django-two-factor-auth-1.15.2::localrepo failed (install phase):
 *   Failing install because of stray top-level files in site-packages
```

## How Has This Been Tested?

The Gentoo package manager installs the package successfully, when the proposed change is included.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
