### PR TITLE
Fix name of replaced migration

### DIFF
--- a/two_factor/plugins/phonenumber/migrations/0001_squashed_0001_initial.py
+++ b/two_factor/plugins/phonenumber/migrations/0001_squashed_0001_initial.py
@@ -73,7 +73,7 @@ class CreatePhoneDevice(Operation):
 class Migration(migrations.Migration):
     replaces = [
         ('phonenumber', '0001_initial'),
-        ('twofactor', '0001_squashed_0008_delete_phonedevice'),
+        ('two_factor', '0001_squashed_0008_delete_phonedevice'),
     ]
 
     initial = True


### PR DESCRIPTION
## Description

In https://github.com/jazzband/django-two-factor-auth/pull/624, the squashed migration declares that it replaces `twofactor`, while the correct name is `two_factor`.

This will result in new installs to always execute `two_factor.0001_squashed_0008_delete_phonedevice`, while they should instead execute only `phonenumber.0001_squashed_0001_initial`.

## How Has This Been Tested?
I run tests on different DB states to verify that the behaviour is correct.
In each test, I did the following operations:
* install the mentioned version of `two_factor`
* run `python manage.py migrate`
* update `two_factor` to 1.15.3 
  * for the run labeled "Before", just run `python manage.py migrate`, and record the result
  * for the run labeled "After", apply the patch of this PR, and then run `python manage.py migrate`, and record the result.

## Test results

<details>
  <summary>Click here to expand</summary>

  ### New install
  #### Before
  Note that we apply `two_factor.0001_squashed_0008_delete_phonedevice`, which is redundant.
  ```
  ❯ python manage.py migrate
  ...
  Running migrations:
    Applying two_factor.0001_squashed_0008_delete_phonedevice... OK
    Applying phonenumber.0001_squashed_0001_initial... OK
  ```
  
  #### After
  Only the `phonenumber.0001_squashed_0001_initial` is applied, as it should.
  ```
  ❯ python manage.py migrate
  ...
  Running migrations:
    Applying phonenumber.0001_squashed_0001_initial... OK
  ```
  
  ### Existing install, DB state up to version 1.14.0
  #### Before
  ```
  ❯ python manage.py migrate
  ...
  Running migrations:
    Applying two_factor.0008_delete_phonedevice... OK
    Applying phonenumber.0001_squashed_0001_initial... OK
  ```
  
  #### After
  ```
  ❯ python manage.py migrate
  ...
  Running migrations:
    Applying two_factor.0008_delete_phonedevice... OK
    Applying phonenumber.0001_squashed_0001_initial... OK
  ```
  
  ### Existing install, DB state up to version 1.15.0
  Note that in both cases, although it says "no migrations to apply", in the `django_migrations` table a new row with the `two_factor.0001_squashed_0008_delete_phonedevice` migration is added.
  #### Before
  ```
  ❯ python manage.py migrate
  ...
  Running migrations:
    No migrations to apply.
  ```
  
  #### After
  ```
  ❯ python manage.py migrate
  ...
  Running migrations:
    No migrations to apply.
  ```
  ### Existing install, DB state up to version 1.15.1
  No changes
  #### Before
  ```
  ❯ python manage.py migrate
  ...
  Running migrations:
    No migrations to apply.
  ```
  
  #### After
  ```
  ❯ python manage.py migrate
  ...
  Running migrations:
    No migrations to apply.
  ```
  
  ### Existing install, DB state up to version 1.15.2
  No changes
  #### Before
  ```
  ❯ python manage.py migrate
  ...
  Running migrations:
    No migrations to apply.
  ```
  
  #### After
  ```
  ❯ python manage.py migrate
  ...
  Running migrations:
    No migrations to apply.
  ```
  
  ### Existing install, DB state up to version 1.15.3
  No changes
  #### Before
  ```
  ❯ python manage.py migrate
  ...
  Running migrations:
    No migrations to apply.
  ```
  
  #### After
  ```
  ❯ python manage.py migrate
  ...
  Running migrations:
    No migrations to apply.
  ```
</details>


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
