### PR TITLE
Revert "refactor: Move registry.get_methods() call to separate method, to all…"

### DIFF
--- a/two_factor/views/core.py
+++ b/two_factor/views/core.py
@@ -496,7 +496,7 @@ class SetupView(RedirectURLMixin, IdempotentSessionWizardView):
         """
         form_list = super().get_form_list()
 
-        available_methods = self.get_available_methods()
+        available_methods = registry.get_methods()
         if len(available_methods) == 1:
             form_list.pop('method', None)
             method_key = available_methods[0].code
@@ -510,9 +510,6 @@ class SetupView(RedirectURLMixin, IdempotentSessionWizardView):
         if {'sms', 'call'} & set(form_list.keys()):
             form_list['validation'] = DeviceValidationForm
         return form_list
-
-    def get_available_methods(self):
-        return registry.get_methods()
 
     def render_next_step(self, form, **kwargs):
         """


### PR DESCRIPTION
Reverts jazzband/django-two-factor-auth#535

This worked fine for simpler cases, but in the end turned out to be useless.

We instead decided to monkey-patch MethodRegistry, and filter choices there, because everything already uses registry.get_methods.