### PR TITLE
Include transitively replaced migrations in phonenumber migration

### DIFF
--- a/two_factor/plugins/phonenumber/migrations/0001_squashed_0001_initial.py
+++ b/two_factor/plugins/phonenumber/migrations/0001_squashed_0001_initial.py
@@ -73,6 +73,10 @@ class CreatePhoneDevice(Operation):
 class Migration(migrations.Migration):
     replaces = [
         ('phonenumber', '0001_initial'),
+        ('two_factor', '0001_initial'), ('two_factor', '0002_auto_20150110_0810'),
+        ('two_factor', '0003_auto_20150817_1733'), ('two_factor', '0004_auto_20160205_1827'),
+        ('two_factor', '0005_auto_20160224_0450'), ('two_factor', '0006_phonedevice_key_default'),
+        ('two_factor', '0007_auto_20201201_1019'), ('two_factor', '0008_delete_phonedevice'),
         ('two_factor', '0001_squashed_0008_delete_phonedevice'),
     ]
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

`phonenumber.0001_squashed_0001_initial` replaces `two_factor.0001_squashed_0008_delete_phonedevice` which itself replaces `two_factor.0001_initial` through `two_factor.0008_delete_phonedevice`, but Django needs these transitive replacements to be expressed directly rather than indirectly.

This fixes a problem where new installs would still execute `two_factor.0001_squashed_0008_delete_phonedevice` the second time migrations are run.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

See https://github.com/jazzband/django-two-factor-auth/pull/642#issuecomment-1690497043.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested with the recipe in https://github.com/jazzband/django-two-factor-auth/pull/642#issuecomment-1690497043.

```console
$ cat > myapp_settings.py <<EOF
DATABASES = {
    "default": {
        "ENGINE": "django.db.backends.sqlite3",
        "NAME": "sqlite3.db",
    }
}
INSTALLED_APPS = [
    "django.contrib.auth",
    "django.contrib.contenttypes",
    "two_factor",
    "two_factor.plugins.phonenumber",
]

$ pip install django 'git+https://github.com/andersk/django-two-factor-auth.git@transitively-replaced#egg=django-two-factor-auth[phonenumberslite]'
…
Successfully installed asgiref-3.7.2 django-4.2.4 django-formtools-2.4.1 django-phonenumber-field-6.4.0 django-two-factor-auth-1.15.4 django_otp-1.2.2 phonenumberslite-8.13.19 pypng-0.20220715.0 qrcode-7.4.2 sqlparse-0.4.4 typing-extensions-4.7.1

$ python -m django migrate --settings=myapp_settings
Operations to perform:
  Apply all migrations: auth, contenttypes, phonenumber
Running migrations:
  Applying contenttypes.0001_initial... OK
  Applying contenttypes.0002_remove_content_type_name... OK
  Applying auth.0001_initial... OK
  Applying auth.0002_alter_permission_name_max_length... OK
  Applying auth.0003_alter_user_email_max_length... OK
  Applying auth.0004_alter_user_username_opts... OK
  Applying auth.0005_alter_user_last_login_null... OK
  Applying auth.0006_require_contenttypes_0002... OK
  Applying auth.0007_alter_validators_add_error_messages... OK
  Applying auth.0008_alter_user_username_max_length... OK
  Applying auth.0009_alter_user_last_name_max_length... OK
  Applying auth.0010_alter_group_name_max_length... OK
  Applying auth.0011_update_proxy_permissions... OK
  Applying auth.0012_alter_user_first_name_max_length... OK
  Applying phonenumber.0001_squashed_0001_initial... OK

$ python -m django migrate --settings=myapp_settings
Operations to perform:
  Apply all migrations: auth, contenttypes, phonenumber
Running migrations:
  No migrations to apply.
```

(Without this fix, this second `migrate` command would unexpectedly apply `two_factor.0001_squashed_0008_delete_phonedevice`.)

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
