### PR TITLE
relax pydantic dependency (fixes #634)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     extras_require={
         'call': ['twilio>=6.0'],
         'sms': ['twilio>=6.0'],
-        'webauthn': ['webauthn>=1.6.0,<1.99', 'pydantic>=1.9.0,<1.99'],
+        'webauthn': ['webauthn>=1.6.0,<1.99', 'pydantic>=1.9.0,<2.99'],
         'yubikey': ['django-otp-yubikey'],
         'phonenumbers': ['phonenumbers>=7.0.9,<8.99'],
         'phonenumberslite': ['phonenumberslite>=7.0.9,<8.99'],

--- a/two_factor/plugins/webauthn/forms.py
+++ b/two_factor/plugins/webauthn/forms.py
@@ -6,7 +6,7 @@ from django.urls import reverse_lazy
 from django.utils import timezone
 from django.utils.module_loading import import_string
 from django.utils.translation import gettext_lazy as _
-from pydantic.error_wrappers import ValidationError as PydanticValidationError
+from pydantic import ValidationError as PydanticValidationError
 from webauthn.helpers.exceptions import InvalidAuthenticationResponse
 from webauthn.helpers.structs import (
     PublicKeyCredentialRpEntity, PublicKeyCredentialUserEntity,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
`ValidationError` is now imported from the "official" place.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Newer versions of [py_webauthn](https://github.com/duo-labs/py_webauthn) also work with pydantic v2. We make use of the `ValidationError` symbol which fortunately is in the same path for both v1 and v2.

<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #634 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
