### PR TITLE
Remove deprecated transifex-client

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -25,10 +25,6 @@ tox
 isort
 freezegun
 
-# Translation
-
-transifex-client
-
 # Documentation
 
 Sphinx


### PR DESCRIPTION
Remove reference to deprecated transifex-client python package.

## Motivation and Context

transifex-client python package is deprecated, as described on https://github.com/transifex/transifex-client/

> Please start using the new Transifex CLI [here](https://github.com/transifex/cli) , since this software is considered deprecated (as of January 2022) and will sunset on Nov 30, 2022.

django-two-factor-auth has transifex-cli currently listed in requirements_dev.txt

Reference to this deprecated package causes confusion for contributors, because when they follow commonsense python flow and install stuff from `requirements_dev.txt`, and then they run `make tx-pull` as described in contributing guidelines they get an error like this:

```
$ make tx-pull
tx pull -a
tx INFO: /home/jan/.transifexrc not found.
tx INFO: Created /home/jan/.transifexrc 
tx ERROR: ValueError: not enough values to unpack (expected 2, got 1)
```

or, if the transifexrc does exist and has modern format:

```
$ make tx-pull
tx pull -a
tx ERROR: configparser.NoOptionError: No option 'hostname' in section: 'https://app.transifex.com'
make: *** [Makefile:40: tx-pull] Error 1
```

## How Has This Been Tested?
I ran the `make tx-pull`. Without the old transifex-client installed I get now a readable error "command not found", instead of head-scratcher "not enough values to unpack" ;-)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


Cheers, Jan Rydzewski