### PR TITLE
Force fetching translation files from transifex

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ coverage:
 	coverage report --precision=2
 
 tx-pull:
-	tx pull -a
+	tx pull -a --force
 	cd two_factor; django-admin compilemessages
 	cd example; django-admin compilemessages
 


### PR DESCRIPTION
In `make tx-pull` make sure we always fetch most recent transifex translation.

## Motivation and Context
The problem is that in some circumstances `make tx-pull` may ignore changes made in transifex. This is because `tx pull -a` command checks file modification timestamps. Adding `--force` ensures we fetch all files regardless of their remote and local modification date.

Line from a help message of `tx pull`:

```
    --force, -f                  Force the download of the translations files regardless of whether timestamps on the local computer are newer than those on the server (default: false)
```

I encountered the problem in the following scenario:

1. I submitted some translations to transifex.
2. I forked and cloned the repo to fetch transifex changes.
3. My changes were not fetched because local modification times was after transifex modification times.

## How Has This Been Tested?
Having installed transifex cli I successfully ran `make tx-pull`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
