### PR TITLE
Adding TOTP_ISSUER as settings value

### DIFF
--- a/two_factor/views/core.py
+++ b/two_factor/views/core.py
@@ -707,6 +707,8 @@ class QRGeneratorView(View):
     }
 
     def get_issuer(self):
+        if settings.TOTP_ISSUER:
+            return settings.TOTP_ISSUER
         return get_current_site(self.request).name
 
     def get_username(self):


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
Using the site name at this point doesn't always make sense. This gives you the possibility to set TOTP_ISSUER in the settings.py file and show this information in the TOTP app.

## Motivation and Context
Depending on the setup, using the sitename could lead to just showing a short name instead of the application name / url. 

## How Has This Been Tested?
Code testing

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
