### PR TITLE
Prevent empty <ul> from being rendered in profile.html

### DIFF
--- a/two_factor/templates/two_factor/profile/profile.html
+++ b/two_factor/templates/two_factor/profile/profile.html
@@ -12,19 +12,21 @@
       <h2>{% trans "Backup Phone Numbers" %}</h2>
       <p>{% blocktrans trimmed %}If your primary method is not available, we are able to
         send backup tokens to the phone numbers listed below.{% endblocktrans %}</p>
-      <ul>
-        {% for phone in backup_phones %}
-          <li>
-            {{ phone|as_action }}
-            <form method="post" action="{% url 'two_factor:phone_delete' phone.id %}"
+      {% if backup_phones %}
+        <ul>
+          {% for phone in backup_phones %}
+            <li>
+              {{ phone|as_action }}
+              <form method="post" action="{% url 'two_factor:phone_delete' phone.id %}"
                   onsubmit="return confirm({% trans 'Are you sure?' %})">
-              {% csrf_token %}
-              <button class="btn btn-sm btn-warning"
+                {% csrf_token %}
+                <button class="btn btn-sm btn-warning"
                       type="submit">{% trans "Unregister" %}</button>
-            </form>
-          </li>
-        {% endfor %}
-      </ul>
+              </form>
+            </li>
+          {% endfor %}
+        </ul>
+      {% endif %}
       <p><a href="{% url 'two_factor:phone_create' %}"
         class="btn btn-info">{% trans "Add Phone Number" %}</a></p>
     {% endif %}


### PR DESCRIPTION
## Description
An empty `<ul>` was being rendered when backup_phones == None.  Whitespace was also being rendered between the `<ul></ul>`.

## Motivation and Context
The rendered element causes extra space to appear in the DOM at http://127.0.0.1:8000/account/two_factor/ before the "Add Phone Number" button when no backup phones have been registered.

## How Has This Been Tested?
Tested locally at http://127.0.0.1:8000/account/two_factor/.  An empty `<ul></ul>` is no longer rendered when navigating to this url prior to adding any backup phone numbers.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
