### PR TITLE
Added some guidance on how to build custom templates to implementing.rst

### DIFF
--- a/docs/implementing.rst
+++ b/docs/implementing.rst
@@ -120,3 +120,36 @@ Users who only have a smartphone will have difficulty scanning the QR code
 during setup. You can directly show the secret key within the QR code in text
 form during setup by providing your own ``two_factor/core/setup.html`` template
 and using the ``secret_key`` context variable.
+
+Custom Templates
+--------------------------------
+To create a custom template, add a template called ``two_factor/_base.html``.
+As a bare minimum, its contents should contain a ``content`` block to load the
+login forms into.
+
+Some plugins, such as WebAuthn, have additional JavaScript that is necessary to
+work properly. These are dynamically loaded in via the ``extra_media`` block
+which should be located in the ``<head>`` tag::
+
+    <!DOCTYPE html>
+    <html>
+    <head>
+      <title>{% block title %}{% endblock %}</title>
+      <meta name="viewport" content="width=device-width, initial-scale=1.0">
+      <link href="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.5.2/css/bootstrap.min.css" rel="stylesheet" media="screen">
+      <script defer src="//cdnjs.cloudflare.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
+      <script defer src="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.5.2/js/bootstrap.min.js"></script>
+      {% block extra_media %}{% endblock %}
+    </head>
+    <body>
+      {% block content_wrapper %}
+        <div class="container">
+          {% block content %}{% endblock %}
+        </div>
+      {% endblock %}
+    </body>
+    </html>
+
+You can also use an existing template by extending it::
+
+    {% extends "your_app_name/base.html" %}


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
While trying to get WebAuthn to work, I couldn't figure out why the input field was readonly and had to dig into the original pull request to figure out I was missing JS. This just clarifies what is needed in custom templates to maintain functionality.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Documentation is lacking any information on how to build the custom templates. The only information available is in the original template: `Provide a template named <code>two_factor/_base.html</code> to style this page and remove this message.`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Just used the `Preview` option when editing the documentation. Otherwise, no functional changes have been made.

## Screenshots (if appropriate):
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
