### PR TITLE
:sparkles: Added support for py webauthn 2.0+

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -15,7 +15,7 @@ django-user-sessions
 
 # Example app (WebAuthn)
 
-webauthn~=1.11.0
+webauthn~=2.0.0
 
 # Testing
 

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     extras_require={
         'call': ['twilio>=6.0'],
         'sms': ['twilio>=6.0'],
-        'webauthn': ['webauthn>=1.11.0,<1.99'],
+        'webauthn': ['webauthn>=2.0,<2.99'],
         'yubikey': ['django-otp-yubikey'],
         'phonenumbers': ['phonenumbers>=7.0.9,<8.99'],
         'phonenumberslite': ['phonenumberslite>=7.0.9,<8.99'],

--- a/tox.ini
+++ b/tox.ini
@@ -45,7 +45,7 @@ deps =
     dj42: Django<5.0
     djmain: https://github.com/django/django/archive/main.tar.gz
     yubikey: django-otp-yubikey
-    webauthn: webauthn>=1.11.0,<1.99
+    webauthn: webauthn>=2.0,<2.99
     webauthn: -rrequirements_e2e.txt
     coverage
     freezegun

--- a/two_factor/plugins/webauthn/forms.py
+++ b/two_factor/plugins/webauthn/forms.py
@@ -6,9 +6,9 @@ from django.urls import reverse_lazy
 from django.utils import timezone
 from django.utils.module_loading import import_string
 from django.utils.translation import gettext_lazy as _
-from pydantic import ValidationError as PydanticValidationError
 from webauthn.helpers.exceptions import (
-    InvalidAuthenticationResponse, InvalidRegistrationResponse,
+    InvalidAuthenticationResponse, InvalidJSONStructure,
+    InvalidRegistrationResponse,
 )
 from webauthn.helpers.parse_authentication_credential_json import (
     parse_authentication_credential_json,
@@ -91,7 +91,7 @@ class WebauthnAuthenticationTokenForm(WebauthnEntitiesFormMixin, AuthenticationT
 
             new_sign_count = verify_authentication_response(
                 device.public_key, device.sign_count, self.webauthn_rp, self.webauthn_origin, challenge, token)
-        except (PydanticValidationError, WebauthnDevice.DoesNotExist, InvalidAuthenticationResponse) as exc:
+        except (InvalidJSONStructure, WebauthnDevice.DoesNotExist, InvalidAuthenticationResponse) as exc:
             raise forms.ValidationError(_('Entered token is not valid.'), code='invalid_token') from exc
 
         device.sign_count = new_sign_count
@@ -136,7 +136,7 @@ class WebauthnDeviceValidationForm(WebauthnEntitiesFormMixin, DeviceValidationFo
 
         try:
             parse_registration_credential_json(token)
-        except InvalidRegistrationResponse as exc:
+        except (InvalidJSONStructure, InvalidRegistrationResponse) as exc:
             raise forms.ValidationError(_('Entered token is not valid.'), code='invalid_token') from exc
 
         self.cleaned_data = {

--- a/two_factor/plugins/webauthn/utils.py
+++ b/two_factor/plugins/webauthn/utils.py
@@ -37,7 +37,7 @@ def make_credential_creation_options(user, rp, excluded_credential_ids, challeng
     creation_options = generate_registration_options(
         rp_id=rp.id,
         rp_name=rp.name,
-        user_id=user.id.decode('utf-8'),
+        user_id=user.id,
         user_name=user.name,
         user_display_name=user.display_name,
         challenge=challenge,


### PR DESCRIPTION
## Description
Closes #701 

WebAuthn 2.0 refactored pydantic usage out of the codebase.

Tests were passing locally with both 1.x and 2.y, but for simplicity's sake, the minimum version is now set to 2.0 so that no compat layer is required.

There doesn't seem to have been a real reason to catch pydantic validation errors - nothing was documented in 96bbd1af and the model does not appear to perform additional validations (see
https://github.com/duo-labs/py_webauthn/blob/v1.11.1/webauthn/authentication/verify_authentication_response.py ), but possibly the base model did. Either way, it was not a tested execution branch.

## Motivation and Context

Drops dependency on Pydantic which may cause version conflicts with other tools.

## How Has This Been Tested?

`tox -e py311-dj42-webauthn` and having the Github CI pipeline. There shouldn't be any functional changes.

## Screenshots (if appropriate):

n/a

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- `n/a` I have added tests to cover my changes.
- [x] All new and existing tests passed. (waiting for CI to run the rest)
