### PR TITLE
:hammer: Re-organize dependencies for local dev and CI

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -15,6 +15,16 @@ Contribute
 * Send a pull request with your changes.
 * Provide a translation using Transifex_.
 
+Local installation
+------------------
+
+Install the development dependencies, which also installs the package in editable mode
+for local development and additional development tools.
+
+.. code-block:: console
+
+    pip install -r requirements_dev.txt
+
 Running tests
 -------------
 This project aims for full code-coverage, this means that your code should be

--- a/docs/requirements.rst
+++ b/docs/requirements.rst
@@ -3,11 +3,12 @@ Requirements
 
 Django
 ------
-Supported Django versions are supported. Currently this list includes Django 3.2, 4.0, 4.1, and 4.2.
+Supported Django versions are supported. Currently this list includes Django 3.2, 4.0,
+4.1, 4.2 and 5.0.
 
 Python
 ------
-The following Python versions are supported: 3.8, 3.9, 3.10 and 3.11 with a
+The following Python versions are supported: 3.8, 3.9, 3.10, 3.11 and 3.12 with a
 limit to what Django itself supports. As support for older Django versions is
 dropped, the minimum version might be raised. See also `What Python version can
 I use with Django?`_.

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,29 +1,12 @@
 # The app itself
 
--e .
-
-# Additional runtime dependencies
-
-twilio
-phonenumberslite
+-e .[call,sms,webauthn,yubikey,phonenumberslite,tests,linting]
 
 # Example app
 
 django-debug-toolbar
 django-bootstrap-form
 django-user-sessions
-
-# Example app (WebAuthn)
-
-webauthn~=2.0.0
-
-# Testing
-
-coverage
-flake8
-tox
-isort
-freezegun
 
 # Documentation
 

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,16 @@ setup(
         'yubikey': ['django-otp-yubikey'],
         'phonenumbers': ['phonenumbers>=7.0.9,<8.99'],
         'phonenumberslite': ['phonenumberslite>=7.0.9,<8.99'],
+        # used internally for local development & CI
+        'tests': [
+            'coverage',
+            'freezegun',
+            'tox',
+        ],
+        'linting': [
+            'flake8<=6.99',
+            'isort<=5.99',
+        ],
     },
     include_package_data=True,
     classifiers=[

--- a/tox.ini
+++ b/tox.ini
@@ -47,12 +47,9 @@ deps =
     dj42: Django<5.0
     dj50: Django<5.1
     djmain: https://github.com/django/django/archive/main.tar.gz
-    yubikey: django-otp-yubikey
-    webauthn: webauthn>=2.0,<2.99
     webauthn: -rrequirements_e2e.txt
-    coverage
-    freezegun
 extras =
+    tests
     call
     phonenumberslite
     yubikey: yubikey
@@ -65,10 +62,10 @@ commands =
 
 [testenv:flake8]
 basepython = python3
-deps = flake8<=6.99
+extras = linting
 commands = flake8 example tests two_factor
 
 [testenv:isort]
 basepython = python3
-deps = isort<=5.99
-commands = isort -rc -c --diff example tests two_factor
+extras = linting
+commands = isort -c --diff example tests two_factor


### PR DESCRIPTION
The 'hard' dependencies are now specified as extra groups in the setup.py package information. tox.ini points to these extras to install the required dependencies, and their supported version ranges.

The dev requirements file is now documented in the contributing guidelines, and makes use of the extras to pull in the optional dependencies for a full-blown local installation. The remaining dependencies (such as sphinx) are not used in tox and are still in the requirements_dev.txt file.

The linting dependencies (with upper bound versions) are now also specified as an extra group to prevent mismatching versions in tox env and local development envs.

## Motivation and Context

`pip install -r requirements_dev.txt` lead to different versions of isort/flak8 being installed in local env and CI pipeline. While it
didn't cause problems yet, these are annoying to track down.

Additionally, when touching minimum required versions, it's hard to keep track of where the version numbers are all specified
and can lead to false negatives in the tests if there are things broken because one specification overrides another.

## How Has This Been Tested?

* Clean virtualenv
* `pip install -r requirements_dev.txt`
* `make example-webauthn`
* `tox`

## Screenshots (if appropriate):

n/a

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Project maintenance

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
