### PR TITLE
Fix invalid token.xml template by adding closing slash to Pause tags 

### DIFF
--- a/tests/test_gateways.py
+++ b/tests/test_gateways.py
@@ -30,33 +30,33 @@ class TwilioGatewayTest(TestCase):
         self.assertEqual(response.content.decode('utf-8'), """<?xml version="1.0" encoding="UTF-8" ?>
 <Response>
   <Say language="en">Your token is:</Say>
-  <Pause>
+  <Pause/>
   <Say language="en">1</Say>
-  <Pause>
+  <Pause/>
   <Say language="en">2</Say>
-  <Pause>
+  <Pause/>
   <Say language="en">3</Say>
-  <Pause>
+  <Pause/>
   <Say language="en">4</Say>
-  <Pause>
+  <Pause/>
   <Say language="en">5</Say>
-  <Pause>
+  <Pause/>
   <Say language="en">6</Say>
-  <Pause>
+  <Pause/>
   <Say language="en">Repeat:</Say>
-  <Pause>
+  <Pause/>
   <Say language="en">1</Say>
-  <Pause>
+  <Pause/>
   <Say language="en">2</Say>
-  <Pause>
+  <Pause/>
   <Say language="en">3</Say>
-  <Pause>
+  <Pause/>
   <Say language="en">4</Say>
-  <Pause>
+  <Pause/>
   <Say language="en">5</Say>
-  <Pause>
+  <Pause/>
   <Say language="en">6</Say>
-  <Pause>
+  <Pause/>
   <Say language="en">Good bye.</Say>
 </Response>\n""")
 

--- a/tests/test_gateways.py
+++ b/tests/test_gateways.py
@@ -1,5 +1,6 @@
 from unittest.mock import Mock, patch
 from urllib.parse import urlencode
+from xml.etree import ElementTree
 
 from django.template.loader import render_to_string
 from django.test import TestCase
@@ -17,7 +18,10 @@ class TwilioGatewayTest(TestCase):
         self.maxDiff = None
         url = reverse('two_factor_twilio:call_app', args=['123456'])
         response = self.client.get(url)
-        self.assertEqual(response.content.decode('utf-8'), """<?xml version="1.0" encoding="UTF-8" ?>
+        content = response.content.decode('utf-8')
+        # raises an exception if invalid xml
+        ElementTree.fromstring(content)
+        self.assertEqual(content, """<?xml version="1.0" encoding="UTF-8" ?>
 <Response>
   <Gather timeout="15" numDigits="1" finishOnKey="">
     <Say language="en">Hi, this is testserver calling. Press any key to continue.</Say>
@@ -27,7 +31,10 @@ class TwilioGatewayTest(TestCase):
 
         url = reverse('two_factor_twilio:call_app', args=['123456'])
         response = self.client.post(url)
-        self.assertEqual(response.content.decode('utf-8'), """<?xml version="1.0" encoding="UTF-8" ?>
+        content = response.content.decode('utf-8')
+        # raises an exception if invalid xml
+        ElementTree.fromstring(content)
+        self.assertEqual(content, """<?xml version="1.0" encoding="UTF-8" ?>
 <Response>
   <Say language="en">Your token is:</Say>
   <Pause/>

--- a/two_factor/templates/two_factor/twilio/token.xml
+++ b/two_factor/templates/two_factor/twilio/token.xml
@@ -1,12 +1,12 @@
 {% load i18n %}<?xml version="1.0" encoding="UTF-8" ?>
 <Response>
   <Say language="{{ locale }}">{% trans "Your token is:" %}</Say>
-  <Pause>
+  <Pause/>
 {% for digit in token %}  <Say language="{{ locale }}">{{ digit }}</Say>
-  <Pause>
+  <Pause/>
 {% endfor %}  <Say language="{{ locale }}">{% trans "Repeat:" %}</Say>
-  <Pause>
+  <Pause/>
 {% for digit in token %}  <Say language="{{ locale }}">{{ digit }}</Say>
-  <Pause>
+  <Pause/>
 {% endfor %}  <Say language="{{ locale }}">{% trans "Good bye." %}</Say>
 </Response>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
In order for XML to be well formed, all elements must have closing tags. Currently, the token.xml template violates this with the unclosed \<Pause\> tags. As described under How Has This Been Tested, I came to the conclusion that the invalid token.xml template results in TwiML that Twilio is unable to parse when making phone calls.

This change was introduced in https://github.com/jazzband/django-two-factor-auth/pull/488 as part of the 1.14.0 release almost two years ago, but I didn't see any open or closed issues related to the phone call functionality being broken which seemed surprising. I briefly looked through [Twilio's changelog](https://github.com/twilio/twilio-python/blob/main/CHANGES.md) to see if there were any Twiml related changes that could explain why this might only be an issue with certain versions of Twilio, but nothing jumped out.

I'm admittedly optimistic that this is a straightforward change that is good to make regardless of how broad the impact is.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I'm in the process of upgrading a project I work on from v1.13.2 to v1.15.5, and encountered an error with the phone call method. The call is made successfully, but after pressing any key to continue, the response is "We're sorry. An application error has occurred. Good bye". After looking at the Twilio log for this call, I noticed that this <Pause> tag is never closed and figured that might be the cause of the error, despite Twilio confirming that the POST request to `twilio/inbound/two_factor/<token>` was successful.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I pasted the following simplified xml into both Twilio's TwiML Bin and a regular XML validator as a sanity check, and both confirmed that the unclosed \<Pause\> tag was invalid, but updating to \<Pause/\> was valid.

Invalid
```
<?xml version="1.0" encoding="UTF-8" ?>
<Response>
  <Pause>
</Response>
```
Valid
```
<?xml version="1.0" encoding="UTF-8" ?>
<Response>
  <Pause/>
</Response>
```
I also updated the automated test that verifies the generated XML is as expected.

Update: I was also able to test this on the project I'm upgrading and confirmed that this change resolves the error encountered with the phone call method.
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
