### PR TITLE
Fix  'RemoteYubikeyDevice' object has no attribute 'throttle_reset'

### DIFF
--- a/tests/test_yubikey.py
+++ b/tests/test_yubikey.py
@@ -6,7 +6,7 @@ from django.apps import apps
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.shortcuts import resolve_url
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.urls import reverse
 
 from .utils import UserMixin
@@ -131,3 +131,31 @@ class YubiKeyTest(UserMixin, TestCase):
         msg = "'otp_yubikey' must be installed to be able to use the yubikey plugin."
         with self.assertRaisesMessage(ImproperlyConfigured, msg):
             apps.get_app_config('yubikey').ready()
+
+    @override_settings(TWO_FACTOR_REMEMBER_COOKIE_AGE=60 * 60)
+    @patch('otp_yubikey.models.RemoteYubikeyDevice.verify_token')
+    def test_login_with_remember_cookie(self, verify_token):
+        user = self.create_user()
+        verify_token.return_value = True
+        service = ValidationService.objects.create(name='default', param_sl='', param_timeout='')
+        user.remoteyubikeydevice_set.create(service=service, name='default')
+
+        response = self.client.post(reverse('two_factor:login'),
+                                    data={'auth-username': 'bouke@example.com',
+                                          'auth-password': 'secret',
+                                          'login_view-current_step': 'auth'})
+        # Should call verify_token
+        token = 'cjikftknbiktlitnbltbitdncgvrbgic'
+        response = self.client.post(reverse('two_factor:login'),
+                                    data={'token-otp_token': token,
+                                          'login_view-current_step': 'token',
+                                          'token-remember': 'on'})
+        self.assertRedirects(response, resolve_url(settings.LOGIN_REDIRECT_URL))
+        verify_token.assert_called_with(token)
+
+        self.client.post(reverse('logout'))
+        response = self.client.post(reverse('two_factor:login'),
+                                    data={'auth-username': 'bouke@example.com',
+                                          'auth-password': 'secret',
+                                          'login_view-current_step': 'auth'})
+        self.assertRedirects(response, resolve_url(settings.LOGIN_REDIRECT_URL))

--- a/two_factor/views/core.py
+++ b/two_factor/views/core.py
@@ -392,10 +392,10 @@ class LoginView(RedirectURLMixin, IdempotentSessionWizardView):
                                 otp_device_id=device.persistent_id
                         ):
                             user.otp_device = device
-                            device.throttle_reset()
+                            getattr(device, "throttle_reset", lambda: None)()
                             return True
                     except BadSignature:
-                        device.throttle_increment()
+                        getattr(device, "throttle_increment", lambda: None)()
                         # Remove remember cookies with invalid signature to omit unnecessary throttling
                         self.cookies_to_delete.append(key)
         return False


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR contains a fix and tests for using the remember me feature with  any device that doesn't implement `throttle_increase` and `throttle_reset`. This includes `RemoteYubikeyDevice`.

## Motivation and Context

As noted in #699 it is very similar to #397. We should not assume every `Device` implements throttle_increase` and `throttle_reset`

## How Has This Been Tested?

I don't own a YubiKey, so testing will rely solely on unit tests.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
