### PR TITLE
Autofocus yubikey field

### DIFF
--- a/two_factor/plugins/yubikey/forms.py
+++ b/two_factor/plugins/yubikey/forms.py
@@ -21,4 +21,4 @@ class YubiKeyAuthenticationForm(AuthenticationTokenForm):
     # YubiKey generates a OTP of 44 characters (not digits). So if the
     # user's primary device is a YubiKey, replace the otp_token
     # IntegerField with a CharField.
-    otp_token = forms.CharField(label=_('YubiKey'), widget=forms.PasswordInput())
+    otp_token = forms.CharField(label=_('YubiKey'), widget=forms.PasswordInput(attrs={'autofocus': True}))


### PR DESCRIPTION
## Description

This PR addresses #289 - it autofocuses the Yubikey field.  I've already forgotten to focus the field manually a few times and it will be much smoother with it auto-focusing.

## Motivation and Context

When using a yubikey, we plugin the device to a USB port, and it acts like a keyboard, typing in the OTP.  It's easy to forget that we need to focus the Yubikey form field, so autofocusing will help make this process smoother.

Closes #289 

## How Has This Been Tested?


<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
