### PR TITLE
registry.get_method should raise an exception

### DIFF
--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,6 +1,8 @@
 from django.test import TestCase
 
-from two_factor.plugins.registry import GeneratorMethod, MethodBase, registry
+from two_factor.plugins.registry import (
+    GeneratorMethod, MethodBase, MethodNotFoundError, registry,
+)
 
 
 class FakeMethod(MethodBase):
@@ -43,3 +45,7 @@ class RegistryTest(TestCase):
 
         registry.unregister('fake-method')
         self.assertEqual(len(registry._methods), expected_length)
+
+    def test_unknown_method(self):
+        with self.assertRaises(MethodNotFoundError):
+            registry.get_method("not-existing-method")

--- a/tests/test_views_profile.py
+++ b/tests/test_views_profile.py
@@ -2,7 +2,7 @@ from django.conf import settings
 from django.test import TestCase, override_settings
 from django.urls import reverse
 
-from two_factor.plugins.registry import registry
+from two_factor.plugins.registry import MethodNotFoundError, registry
 
 from .utils import UserMixin
 
@@ -27,8 +27,10 @@ class ProfileTest(UserMixin, TestCase):
             app for app in settings.INSTALLED_APPS if app != 'two_factor.plugins.phonenumber']
 
         with override_settings(INSTALLED_APPS=without_phonenumber_plugin):
-            self.assertFalse(registry.get_method('call'))
-            self.assertFalse(registry.get_method('sms'))
+            with self.assertRaises(MethodNotFoundError):
+                registry.get_method('call')
+            with self.assertRaises(MethodNotFoundError):
+                registry.get_method('sms')
 
             response = self.get_profile()
 

--- a/two_factor/plugins/phonenumber/utils.py
+++ b/two_factor/plugins/phonenumber/utils.py
@@ -2,7 +2,7 @@ import re
 
 import phonenumbers
 
-from two_factor.plugins.registry import registry
+from two_factor.plugins.registry import MethodNotFoundError, registry
 
 phone_mask = re.compile(r'(?<=.{3})[0-9](?=.{2})')
 
@@ -10,7 +10,11 @@ phone_mask = re.compile(r'(?<=.{3})[0-9](?=.{2})')
 def get_available_phone_methods():
     methods = []
     for code in ['sms', 'call']:
-        if method := registry.get_method(code):
+        try:
+            method = registry.get_method(code)
+        except MethodNotFoundError:
+            pass
+        else:
             methods.append(method)
 
     return methods

--- a/two_factor/plugins/registry.py
+++ b/two_factor/plugins/registry.py
@@ -1,6 +1,15 @@
 from django.utils.translation import gettext_lazy as _
 
 
+class MethodNotFoundError(LookupError):
+    """Registry method was not found
+
+    Check that the appropriate method has been registered
+    """
+    def __init__(self, code, methods):
+        super().__init__(f"{code} not found in {[m.code for m in methods]}")
+
+
 class MethodBase:
     code = None
     verbose_name = None
@@ -90,7 +99,7 @@ class MethodRegistry:
         try:
             return [meth for meth in self._methods if meth.code == code][0]
         except IndexError:
-            return None
+            raise MethodNotFoundError(code, self._methods)
 
     def get_methods(self):
         return self._methods


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

`registry.get_method` has been changed to raise an exception, `MethodNotFoundError`, when it encounters a unregistered method.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Returning None makes it more difficult to track down cases where an unregistered method has been used as it results in an unhelpful error such as reported in #717

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
A new test has been added and old tests have been updated.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
