### PR TITLE
Fix ruff invocation in tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -63,7 +63,7 @@ commands =
 [testenv:ruff]
 basepython = python3
 extras = linting
-commands = ruff .
+commands = ruff check .
 
 [testenv:isort]
 basepython = python3


### PR DESCRIPTION
## Description
Fixes the following error when running ruff with tox:

`ruff <path>` has been removed. Use `ruff check <path>` instead.

## How Has This Been Tested?
Running `tox -e ruff`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
