### PR TITLE
fix remember device cookie key str

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,4 @@
+import string
 from unittest import mock
 from urllib.parse import parse_qsl, urlparse
 
@@ -137,6 +138,17 @@ class UtilsTest(UserMixin, TestCase):
             otp_device_id="SomeModel/34",
         )
         self.assertFalse(validation_result)
+
+    def test_cookie_valid_characters(self):
+        user = mock.Mock()
+        user.pk = 123
+        user.password = make_password("xx")
+        allowed_characters = set(string.ascii_letters + string.digits + "-_:")
+
+        cookie_value = get_remember_device_cookie(
+            user=user, otp_device_id="SomeModel/33"
+        )
+        self.assertTrue(all(c in allowed_characters for c in cookie_value))
 
 
 class PhoneUtilsTests(UserMixin, TestCase):

--- a/two_factor/views/utils.py
+++ b/two_factor/views/utils.py
@@ -1,4 +1,4 @@
-import base64
+import hashlib
 import logging
 import time
 
@@ -290,7 +290,7 @@ def validate_remember_device_cookie(cookie, user, otp_device_id):
 
 
 def hash_remember_device_cookie_key(otp_device_id):
-    return str(base64.b64encode(force_bytes(otp_device_id)))
+    return hashlib.md5(force_bytes(otp_device_id)).hexdigest()
 
 
 def hash_remember_device_cookie_value(otp_device_id, user, timestamp):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix generating cookie string for trusted device.

## Motivation and Context
Incorrect insertion of byte strings into cookies was observed, resulting in entries like: "1sStq4:b'b3RwX3RvdHAudG90cGRldmljZS8yNQ==':6d4ce2b43b302cff74ce8f96ed31a1ae01ec95811712093c6f165683ac5a723b".  
With raw b'', trailing '==' and extra quotation marks.

After fix it looks like this: 1sSjI3:7070fce2154941bcd83a76677c93c9fd:19aa65d49670a1c73ea8201858a0dbbff1934a59fbcf659941a2f2ee5831b2ea


## How Has This Been Tested?
I tested this fix in my project that uses this library and verified it with the existing tests in the library.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
