### PR TITLE
Change EmailDevice default to unconfirmed until verified

### DIFF
--- a/two_factor/plugins/email/method.py
+++ b/two_factor/plugins/email/method.py
@@ -30,7 +30,7 @@ class EmailMethod(MethodBase):
             request.user.save(update_fields=['email'])
         device = EmailDevice.objects.devices_for_user(request.user).first()
         if not device:
-            device = EmailDevice(user=request.user, name='default')
+            device = EmailDevice(user=request.user, name='default', confirmed=False)
         return device
 
     def get_token_form_class(self):

--- a/two_factor/utils.py
+++ b/two_factor/utils.py
@@ -6,12 +6,12 @@ from django_otp import devices_for_user
 USER_DEFAULT_DEVICE_ATTR_NAME = "_default_device"
 
 
-def default_device(user):
+def default_device(user, confirmed=True):
     if not user or user.is_anonymous:
         return
     if hasattr(user, USER_DEFAULT_DEVICE_ATTR_NAME):
         return getattr(user, USER_DEFAULT_DEVICE_ATTR_NAME)
-    for device in devices_for_user(user):
+    for device in devices_for_user(user, confirmed=confirmed):
         if device.name == 'default':
             setattr(user, USER_DEFAULT_DEVICE_ATTR_NAME, device)
             return device

--- a/two_factor/views/core.py
+++ b/two_factor/views/core.py
@@ -548,6 +548,7 @@ class SetupView(RedirectURLMixin, IdempotentSessionWizardView):
         # PhoneNumberForm / YubiKeyDeviceForm / EmailForm / WebauthnDeviceValidationForm
         elif method.code in ('call', 'sms', 'yubikey', 'email', 'webauthn'):
             device = self.get_device()
+            device.confirmed = True
             device.save()
 
         django_otp.login(self.request, device)


### PR DESCRIPTION
Related to https://github.com/jazzband/django-two-factor-auth/issues/751

## Description
We change EmailDevice default to unconfirmed (confirmed False) because until the email is actually verified with OTP, we should not assume that flow is finished and user properly setup the OTP. This changes the default property confirmed to False, and adds a test to ensure we get a device created in a confirmed False state.

## Motivation and Context
https://github.com/jazzband/django-two-factor-auth/issues/751
https://github.com/jazzband/django-two-factor-auth/issues/562

## How Has This Been Tested?
Ran existing tests + added a new single test to confirm it creates an unconfirmed device if code is not validated. I also tested with the provided example app, starting the setup flow with email, then cancelling it without entering the code, checking from the shell/admin that email device is created with first unconfirmed, then confirmed state.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
