### PR TITLE
Fix webauthn test weirdness by waiting for login to finish

### DIFF
--- a/two_factor/plugins/webauthn/tests/test_e2e.py
+++ b/two_factor/plugins/webauthn/tests/test_e2e.py
@@ -71,6 +71,9 @@ class E2ETests(UserMixin, StaticLiveServerTestCase):
         button_next = self.webdriver.find_element(By.XPATH, "//button[@type='submit']")
         button_next.click()
 
+        # wait for login to complete before moving on
+        self.wait_for_url(urljoin(self.base_url, reverse("two_factor:profile")))
+
     def register_authenticator(self):
         self.webdriver.get(urljoin(self.base_url, reverse("two_factor:setup")))
         self.webdriver.find_element(By.XPATH, "//button[@type='submit']").click()


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

In webauthn end-to-end tests we now wait for login to finish before proceeding with 2FA setup . Without this the Selenium ends up loading the wrong URL

## Motivation and Context

See #754 

## How Has This Been Tested?

Tests now pass.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
