### PR TITLE
Update supported Python versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
     env:
       COVERAGE_OPTIONS: "-a"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,8 +8,8 @@ jobs:
     name: Python ${{ matrix.python-version }}
     runs-on: ubuntu-latest
     strategy:
-      matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+      matrix: # only run tests on the min & max supported versions of Python
+        python-version: ['3.9', '3.13']
     env:
       COVERAGE_OPTIONS: "-a"
 

--- a/docs/requirements.rst
+++ b/docs/requirements.rst
@@ -4,7 +4,7 @@ Requirements
 Django
 ------
 Supported Django versions are supported. Currently this list includes Django 4.2,
-5.0 and 5.1.
+5.0, 5.1 and 5.2.
 
 Python
 ------

--- a/docs/requirements.rst
+++ b/docs/requirements.rst
@@ -8,7 +8,7 @@ Supported Django versions are supported. Currently this list includes Django 4.2
 
 Python
 ------
-The following Python versions are supported: 3.8, 3.9, 3.10, 3.11 and 3.12 with a
+The following Python versions are supported: 3.9, 3.10, 3.11, 3.12 and 3.13 with a
 limit to what Django itself supports. As support for older Django versions is
 dropped, the minimum version might be raised. See also `What Python version can
 I use with Django?`_.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ classifiers = [
     "Framework :: Django :: 4.2",
     "Framework :: Django :: 5.0",
     "Framework :: Django :: 5.1",
+    "Framework :: Django :: 5.2",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ maintainers = [
   {name = "Matt Molyneaux", email = "moggers87+git@moggers87.co.uk"},
 ]
 license = {text = "MIT"}
-requires-python = ">= 3.8"
+requires-python = ">= 3.9"
 dependencies = [
     "Django>=4.2",
     "django_otp>=0.8.0",
@@ -37,11 +37,11 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Security",
     "Topic :: System :: Systems Administration :: Authentication/Directory",
 ]
@@ -71,7 +71,7 @@ Changelog = "https://github.com/jazzband/django-two-factor-auth/blob/master/CHAN
 
 [tool.ruff]
 line-length = 119
-target-version = "py38"
+target-version = "py39"
 extend-exclude = ["docs"]
 
 [tool.ruff.lint]

--- a/requirements_e2e.txt
+++ b/requirements_e2e.txt
@@ -1,2 +1,2 @@
 # test with selenium
-selenium~=4.16.0
+selenium~=4.30.0

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist =
     py{39,310,311,312}-dj42-{normal,yubikey,custom_user,webauthn}
     py{310,311,312}-dj50-{normal,yubikey,custom_user,webauthn}
-    py{310,311,312,313}-dj51-{normal,yubikey,custom_user,webauthn}
+    py{310,311,312,313}-dj{51,52}-{normal,yubikey,custom_user,webauthn}
     py{312,313}-djmain-{normal,yubikey,custom_user,webauthn}
 
 [gh-actions]
@@ -18,6 +18,7 @@ DJANGO =
     4.2: dj42
     5.0: dj50
     5.1: dj51
+    5.2: dj52
     main: djmain
 VARIANT =
     normal: normal
@@ -43,6 +44,7 @@ deps =
     dj42: Django<5.0
     dj50: Django<5.1
     dj51: Django<5.2
+    dj52: Django<5.3
     djmain: https://github.com/django/django/archive/main.tar.gz
     webauthn: -rrequirements_e2e.txt
 extras =

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,17 @@
 [tox]
 envlist =
-    py{38,39,310,311,312}-dj42-{normal,yubikey,custom_user,webauthn}
-    py{310,311,312}-dj{50,51,main}-{normal,yubikey,custom_user,webauthn}
+    py{39,310,311,312}-dj42-{normal,yubikey,custom_user,webauthn}
+    py{310,311,312}-dj50-{normal,yubikey,custom_user,webauthn}
+    py{310,311,312,313}-dj51-{normal,yubikey,custom_user,webauthn}
+    py{312,313}-djmain-{normal,yubikey,custom_user,webauthn}
 
 [gh-actions]
 python =
-    3.8: py38
     3.9: py39
     3.10: py310
     3.11: py311
     3.12: py312
+    3.13: py313
 
 [gh-actions:env]
 DJANGO =
@@ -32,11 +34,11 @@ setenv =
     PYTHONWARNINGS=always
     custom_user: AUTH_USER_MODEL=tests.User
 basepython =
-    py38: python3.8
     py39: python3.9
     py310: python3.10
     py311: python3.11
     py312: python3.12
+    py313: python3.13
 deps =
     dj42: Django<5.0
     dj50: Django<5.1


### PR DESCRIPTION
Python 3.8 ended support back in October and Python 3.13 is supported by Django 5.1

## Description

- Removed Python 3.8 from tox, Github actions, etc.
- Added Python 3.13 to tox, Github actions, etc.
- Bumped up Selenium version installed for testing
- Stop testing Python 3.10 and 3.11 against Django main

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

Ran `tox` locally and all tests passed

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
