### PR TITLE
Fix infinite login redirect on admin site with AdminSiteOTPRequiredMixin

### DIFF
--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -1,11 +1,15 @@
+from binascii import unhexlify
+
 from django.conf import settings
 from django.shortcuts import resolve_url
 from django.test import TestCase
 from django.test.utils import override_settings
+from django.urls import reverse
+from django_otp.oath import totp
 
 from two_factor.admin import patch_admin, unpatch_admin
 
-from .utils import UserMixin
+from .utils import UserMixin, method_registry
 
 
 @override_settings(ROOT_URLCONF='tests.urls_admin')
@@ -48,15 +52,16 @@ class OTPAdminSiteTest(UserMixin, TestCase):
     def setUp(self):
         super().setUp()
         self.user = self.create_superuser()
-        self.login_user()
 
     def test_otp_admin_without_otp(self):
+        self.login_user()
         response = self.client.get('/otp_admin/', follow=True)
         redirect_to = '%s?next=/otp_admin/' % resolve_url(settings.LOGIN_URL)
         self.assertRedirects(response, redirect_to)
 
     @override_settings(LOGIN_URL='two_factor:login')
     def test_otp_admin_without_otp_named_url(self):
+        self.login_user()
         response = self.client.get('/otp_admin/', follow=True)
         redirect_to = '%s?next=/otp_admin/' % resolve_url(settings.LOGIN_URL)
         self.assertRedirects(response, redirect_to)
@@ -66,3 +71,41 @@ class OTPAdminSiteTest(UserMixin, TestCase):
         self.login_user()
         response = self.client.get('/otp_admin/')
         self.assertEqual(response.status_code, 200)
+
+    @method_registry(['generator'])
+    def test_otp_admin_login_redirect_without_otp(self):
+        # Open URL that is protected
+        #  assert go to login page
+        #  assert the next param not in the session (but still in url)
+        response = self.client.get('/otp_admin/', follow=True)
+        redirect_to = '%s?next=/otp_admin/' % resolve_url(settings.LOGIN_URL)
+        self.assertRedirects(response, redirect_to)
+        self.assertEqual(self.client.session.get('next'), None)
+
+        # Log in given the last redirect
+        #  assert redirect to setup
+        response = self.client.post(
+            redirect_to,
+            {'auth-username': 'bouke@example.com', 'auth-password': 'secret', 'login_view-current_step': 'auth'},
+        )
+        self.assertRedirects(response, reverse('two_factor:setup'))
+        self.assertEqual(self.client.session.get('next'), '/otp_admin/')
+
+        # Setup the device accordingly
+        #  assert redirect to setup completed
+        #  assert button for redirection to the original page
+        response = self.client.post(reverse('two_factor:setup'), data={'setup_view-current_step': 'welcome'})
+        self.assertContains(response, 'Token:')
+        self.assertContains(response, 'autofocus="autofocus"')
+        self.assertContains(response, 'inputmode="numeric"')
+        self.assertContains(response, 'autocomplete="one-time-code"')
+
+        key = response.context_data['keys'].get('generator')
+        bin_key = unhexlify(key.encode())
+        response = self.client.post(
+            reverse('two_factor:setup'),
+            data={'setup_view-current_step': 'generator', 'generator-token': totp(bin_key)},
+            follow=True,
+        )
+
+        self.assertRedirects(response, '/otp_admin/')

--- a/two_factor/views/mixins.py
+++ b/two_factor/views/mixins.py
@@ -4,6 +4,7 @@ from django.core.exceptions import PermissionDenied
 from django.template.response import TemplateResponse
 from django.urls import Resolver404, resolve, reverse
 
+from ..admin import AdminSiteOTPRequiredMixin
 from ..utils import default_device
 
 
@@ -90,4 +91,7 @@ class OTPRequiredMixin:
         return (
             hasattr(next_resolver_match.func, 'view_class') and
             issubclass(next_resolver_match.func.view_class, OTPRequiredMixin)
+        ) or (
+            hasattr(next_resolver_match.func, 'admin_site') and
+            isinstance(next_resolver_match.func.admin_site, AdminSiteOTPRequiredMixin)
         )


### PR DESCRIPTION
When using AdminSiteOTPRequiredMixin, users who don't have 2FA set up will face an infinite login redirect, similar to the behaviour prior to #499/#500.

In #558, a change was made to fix a regression introduced by #500 by restricting when the 2FA setup login redirect will apply. But, the restriction logic only considers the use of OTPRequiredMixin. It doesn't consider the use of AdminSiteOTPRequiredMixin. Thus, users of AdminSiteOTPRequiredMixin on their admin site will still see the same broken infinite redirect behaviour from before.

This changes the logic added in #558 to also consider AdminSiteOTPRequiredMixin in addition to OTPRequiredMixin.

## Description
Update the is_otp_view logic to additionally consider views that are part of an admin site with the AdminSiteOTPRequiredMixin as OTP views.

## Motivation and Context
Fixes the infinite login redirect for admin sites, first described in #499, fixed in #500, then regressed for admin sites specifically in #558.

## How Has This Been Tested?
I applied this change to my workplace's Django 4.2.20 app and tried it out by hand to confirm that the infinite redirect is fixed for our admin site. Additionally, I copied the test from #500 which tests the redirect flow for logged out users without OTP on OTP required views but applied it to the OTPAdminSite.

Before the change:

```
FAIL: test_otp_admin_login_redirect_without_otp (tests.test_admin.OTPAdminSiteTest.test_otp_admin_login_redirect_without_otp)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/shawnz/Documents/GitHub/django-two-factor-auth/.venv/lib/python3.13/site-packages/django/test/utils.py", line 456, in inner
    return func(*args, **kwargs)
  File "/Users/shawnz/Documents/GitHub/django-two-factor-auth/tests/test_admin.py", line 91, in test_otp_admin_login_redirect_without_otp
    self.assertRedirects(response, reverse('two_factor:setup'))
    ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError: 302 != 200 : Couldn't retrieve redirection page '/otp_admin/': response code was 302 (expected 200)

----------------------------------------------------------------------
Ran 165 tests in 2.713s

FAILED (failures=1, skipped=1)
```

After the change:

```
----------------------------------------------------------------------
Ran 165 tests in 2.709s

OK (skipped=1)
```

## Screenshots (if appropriate):
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
