### PR TITLE
chore: split `issue` templates, move them to `ISSUE_TEMPLATES` folder

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,34 +1,50 @@
+---
+name: Bug report
+about: Create a report to help us improve django-two-factor-auth
+title: "BUG: Short description of the problem"
+labels: "bug"
+assignees: ""
+---
+
 <!--- Provide a general summary of the issue in the Title above -->
 
 ## Expected Behavior
+
 <!--- If you're describing a bug, tell us what should happen -->
 <!--- If you're suggesting a change/improvement, tell us how it should work -->
 
 ## Current Behavior
+
 <!--- If describing a bug, tell us what happens instead of the expected behavior -->
 <!--- If suggesting a change/improvement, explain the difference from current behavior -->
 
 ## Possible Solution
+
 <!--- Not obligatory, but suggest a fix/reason for the bug, -->
 <!--- or ideas how to implement the addition or change -->
 
 ## Steps to Reproduce (for bugs)
+
 <!--- Provide a link to a live example, or an unambiguous set of steps to -->
 <!--- reproduce this bug. Include code to reproduce, if relevant -->
+
 1.
 2.
 3.
 4.
 
 ## Context
+
 <!--- How has this issue affected you? What are you trying to accomplish? -->
 <!--- Providing context helps us come up with a solution that is most useful in the real world -->
 
 ## Your Environment
+
 <!--- Include as many relevant details about the environment you experienced the bug in -->
-* Browser and version:
-* Python version:
-* Django version:
-* django-otp version:
-* django-two-factor-auth version:
-* Link to your project:
+
+- Browser and version:
+- Python version:
+- Django version:
+- django-otp version:
+- django-two-factor-auth version:
+- Link to your project:

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -11,17 +11,14 @@ assignees: ""
 ## Expected Behavior
 
 <!--- If you're describing a bug, tell us what should happen -->
-<!--- If you're suggesting a change/improvement, tell us how it should work -->
 
 ## Current Behavior
 
 <!--- If describing a bug, tell us what happens instead of the expected behavior -->
-<!--- If suggesting a change/improvement, explain the difference from current behavior -->
 
 ## Possible Solution
 
-<!--- Not obligatory, but suggest a fix/reason for the bug, -->
-<!--- or ideas how to implement the addition or change -->
+<!--- Not obligatory, but suggest a fix/reason for the bug -->
 
 ## Steps to Reproduce (for bugs)
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest an idea for django-two-factor-auth
 title: "FEATURE REQUEST: Short description of requested feature"
-labels: "feature request"
+labels: "enhancement"
 assignees: ""
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,19 @@
+---
+name: Feature request
+about: Suggest an idea for django-two-factor-auth
+title: "FEATURE REQUEST: Short description of requested feature"
+labels: "feature request"
+assignees: ""
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Resolves #753
## Description
<!--- Describe your changes in detail -->
This PR upgrades issue templates (current issue template is not being used by github). I also split issue templates to `bug_report` and `feature_request` with adding a little "sugar", i.e. auto-labeling and title template (the same way I did in [django-axes](https://github.com/jazzband/django-axes)) 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I think motivation is pretty clear:)
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
You can look how it works at `django-axes` repo
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
