### PR TITLE
Simple system check to protect against wrong INSTALLED_APPS order

### DIFF
--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -1,0 +1,20 @@
+from django.core.checks import Error, Warning
+from django.test import TestCase, override_settings
+
+from two_factor import checks
+
+
+class InstallAppOrderCheckTest(TestCase):
+    @override_settings(INSTALLED_APPS=("django_otp", "two_factor", "two_factor.plugins.email"))
+    def test_correct(self):
+        self.assertEqual(checks.check_installed_app_order(None), [])
+
+    @override_settings(INSTALLED_APPS=("django_otp", "two_factor.plugins.email", "two_factor"))
+    def test_incorrect(self):
+        self.assertEqual(checks.check_installed_app_order(None),
+            [Error(checks.INSTALLED_APPS_MSG, hint=checks.INSTALLED_APPS_HINT, id=checks.INSTALLED_APPS_ID)])
+
+    @override_settings(INSTALLED_APPS=("django_otp", "two_factor.apps.TwoFactorConfig", "two_factor.plugins.email"))
+    def test_two_factor_not_found(self):
+        self.assertEqual(checks.check_installed_app_order(None),
+            [Warning(checks.MISSING_MSG, hint=checks.MISSING_HINT, id=checks.MISSING_ID)])

--- a/two_factor/apps.py
+++ b/two_factor/apps.py
@@ -7,6 +7,7 @@ class TwoFactorConfig(AppConfig):
     verbose_name = "Django Two Factor Authentication"
 
     def ready(self):
+        from . import checks  # noqa
         if getattr(settings, 'TWO_FACTOR_PATCH_ADMIN', True):
             from .admin import patch_admin
             patch_admin()

--- a/two_factor/checks.py
+++ b/two_factor/checks.py
@@ -1,0 +1,31 @@
+from django.conf import settings
+from django.core.checks import Error, Warning, register
+
+INSTALLED_APPS_MSG = "two_factor should come before its plugins in INSTALLED_APPS"
+INSTALLED_APPS_HINT = "Check documentation for proper ordering."
+INSTALLED_APPS_ID = "two_factor.E001"
+
+MISSING_MSG = "Could not reliably determine where in INSTALLED_APPS two_factor appears"
+MISSING_HINT = INSTALLED_APPS_HINT
+MISSING_ID = "two_factor.W001"
+
+@register()
+def check_installed_app_order(app_configs, **kwargs):
+    """Check the order in which two_factor and its plugins are loaded"""
+    apps = [app for app in settings.INSTALLED_APPS if app.startswith("two_factor")]
+    if "two_factor" not in apps:
+        # user might be using "two_factor.apps.TwoFactorConfig" or their own
+        # custom app config for two_factor, so give them a warning
+        return [Warning(
+            MISSING_MSG,
+            hint=MISSING_HINT,
+            id=MISSING_ID,
+        )]
+    elif apps[0] != "two_factor":
+        return [Error(
+            INSTALLED_APPS_MSG,
+            hint=INSTALLED_APPS_HINT,
+            id=INSTALLED_APPS_ID,
+        )]
+
+    return []


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Register a check with Django's check system that looks at `INSTALLED_APPS` and returns an error if it finds `two_factor` comes after one of its plugins.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Putting two_factor and its plugins in the wrong order can cause all sorts of weird issues that are difficult to debug.

See #647 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests have been written and I tried the check command on the example app

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
