### PR TITLE
WebAuthn: Avoid submitting the wrong form

### DIFF
--- a/two_factor/plugins/webauthn/templates/two_factor_webauthn/create_credential.js
+++ b/two_factor/plugins/webauthn/templates/two_factor_webauthn/create_credential.js
@@ -20,7 +20,7 @@ navigator.credentials.create({
             type: attestationCredential.type,
         },
         tokenField = document.querySelector('[name=webauthn-token]'),
-        form = document.forms[0];
+        form = tokenField.closest('form');
 
     tokenField.value = JSON.stringify(serializableAttestationCredential);
     form.submit();


### PR DESCRIPTION
## Description
If the template is modified/overridden, there could be other forms before the two-factor one. This selects the form based on the tokenField input. This uses the `Element.closest` method that "traverses the element and its parents", which should be available to 95.2% of users according to [Can I Use?](https://caniuse.com/mdn-api_element_closest).

## Motivation and Context
I'm working on an internal project to integrate two-factor login to the Django admin (as others have tried: #169), and so far so good, but if the passkey setup is done inside the admin panel, the logout form (link) is triggered instead the two-factor form, since the Javascript selects the form based on the `document.forms[0]` line. This instead searches the closest form to the two-factor token input.

No, this small merge request does not integrate the project into the django-admin. But I could eventually work in a PR to do this, if everything goes as expected.

## How Has This Been Tested?
I'm running this modification and testing it live in my django-admin environment. I haven't tested further since it's not a profound change.

## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/87f3b4b9-288c-46bd-8b13-154907858a04)

In the screenshot, you can see the WebAuthn setup integrated to the admin. Once the token is activated, it was triggering the logout action and I didn't understand why, until I saw how the form was being selected.

![image](https://github.com/user-attachments/assets/f90144bf-de40-4cd2-a625-c65947e65104)

*(congratulations screen)*

With this small fix, I can successfully store the key on my account.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
