### PR TITLE
Refs #469 - Only import phonenumber functions when plugin is installed

### DIFF
--- a/tests/test_views_profile.py
+++ b/tests/test_views_profile.py
@@ -34,7 +34,7 @@ class ProfileTest(UserMixin, TestCase):
 
             response = self.get_profile()
 
-        self.assertTrue(response.context['available_phone_methods'] == [])
+        self.assertNotIn('available_phone_methods', response.context)
 
     def test_get_profile_with_phonenumer_plugin_enabled(self):
         self.assertTrue(registry.get_method('call'))

--- a/two_factor/views/core.py
+++ b/two_factor/views/core.py
@@ -9,6 +9,7 @@ from uuid import uuid4
 import django_otp
 import qrcode
 import qrcode.image.svg
+from django.apps import apps
 from django.conf import settings
 from django.contrib.auth import REDIRECT_FIELD_NAME, login
 from django.contrib.auth.decorators import login_required
@@ -36,7 +37,6 @@ from django_otp.plugins.otp_static.models import StaticToken
 from django_otp.util import random_hex
 
 from two_factor import signals
-from two_factor.plugins.phonenumber.utils import get_available_phone_methods
 from two_factor.plugins.registry import MethodNotFoundError, registry
 from two_factor.utils import totp_digits
 from two_factor.views.mixins import OTPRequiredMixin
@@ -682,9 +682,18 @@ class SetupCompleteView(TemplateView):
             return redirect(request.session.get('next'))
         return super().get(request, *args, **kwargs)
 
-    def get_context_data(self):
+    def get_context_data(self, **kwargs):
+        phone_methods = None
+        if (apps.is_installed("two_factor.plugins.phonenumber")):
+            from two_factor.plugins.phonenumber.utils import (
+                get_available_phone_methods,
+            )
+
+            phone_methods = get_available_phone_methods()
+
         return {
-            'phone_methods': get_available_phone_methods(),
+            **super().get_context_data(**kwargs),
+            "phone_methods": phone_methods,
         }
 
 

--- a/two_factor/views/profile.py
+++ b/two_factor/views/profile.py
@@ -1,3 +1,4 @@
+from django.apps import apps
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.shortcuts import redirect, resolve_url
@@ -7,10 +8,6 @@ from django.views.decorators.cache import never_cache
 from django.views.generic import FormView, TemplateView
 from django_otp import devices_for_user
 from django_otp.decorators import otp_required
-
-from two_factor.plugins.phonenumber.utils import (
-    backup_phones, get_available_phone_methods,
-)
 
 from ..forms import DisableForm
 from ..utils import default_device
@@ -36,13 +33,22 @@ class ProfileView(TemplateView):
         except Exception:
             backup_tokens = 0
 
-        context = {
+        context = super().get_context_data(**kwargs)
+        context.update({
             'default_device': default_device(user),
             'default_device_type': default_device(user).__class__.__name__,
             'backup_tokens': backup_tokens,
-            'backup_phones': backup_phones(user),
-            'available_phone_methods': get_available_phone_methods(),
-        }
+        })
+
+        if apps.is_installed("two_factor.plugins.phonenumber"):
+            from two_factor.plugins.phonenumber.utils import (
+                backup_phones, get_available_phone_methods,
+            )
+
+            context.update({
+                "backup_phones": backup_phones(self.request.user),
+                "available_phone_methods": get_available_phone_methods(),
+            })
 
         return context
 


### PR DESCRIPTION
Read discussion on #469 for more details. In the longer term, plugins should be able to fill view contexts through a pluggable method. But for now, this looks like a reasonable workaround.
