### PR TITLE
Replace colons in otpauth issuer and account name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 ### Fixed
 - Compile translation files for Azerbaijani and Serbian, forgotten in 1.18.1.
+- Replace colons in otpauth issuer and account name so FreeOTP accepts QR
+  codes from sites on a non-standard port (#768).
 
 ## 1.18.1
 ### Added

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -75,6 +75,19 @@ class UtilsTest(UserMixin, TestCase):
                                 issuer='测试网站',
                                 secret='abcdef123', digits=num_digits))
 
+    def test_get_otpauth_url_replaces_colons(self):
+        # Key URI Format forbids colons in issuer and account name. A site
+        # name like 127.0.0.1:8000 used to produce a label FreeOTP rejects.
+        self.assertEqualUrl(
+            'otpauth://totp/127.0.0.1-8000%3A%20moggers?'
+            'secret=abcdef123&digits=6&issuer=127.0.0.1-8000',
+            get_otpauth_url(accountname='moggers', issuer='127.0.0.1:8000',
+                            secret='abcdef123', digits=6))
+        self.assertEqualUrl(
+            'otpauth://totp/user-name?secret=abcdef123&digits=6',
+            get_otpauth_url(accountname='user:name', secret='abcdef123',
+                            digits=6))
+
     def assertEqualUrl(self, lhs, rhs):
         """
         Asserts whether the URLs are canonically equal.

--- a/two_factor/utils.py
+++ b/two_factor/utils.py
@@ -21,10 +21,11 @@ def get_otpauth_url(accountname, secret, issuer=None, digits=None):
     # For a complete run-through of all the parameters, have a look at the
     # specs at:
     # https://github.com/google/google-authenticator/wiki/Key-Uri-Format
+    # Neither issuer nor account name may contain a colon.
 
     # quote and urlencode work best with bytes, not unicode strings.
-    accountname = accountname.encode('utf8')
-    issuer = issuer.encode('utf8') if issuer else None
+    accountname = accountname.replace(':', '-').encode('utf8')
+    issuer = issuer.replace(':', '-').encode('utf8') if issuer else None
 
     label = quote(b': '.join([issuer, accountname]) if issuer else accountname)
 


### PR DESCRIPTION
## Description

`get_otpauth_url` now replaces `:` with `-` in both the issuer and the account name before building the Key URI label and `issuer` query parameter.

## Motivation and Context

The [Key URI Format](https://github.com/google/google-authenticator/wiki/Key-Uri-Format#label) says neither issuer nor account name may contain a colon. When the Django site name is a host:port (for example `127.0.0.1:8000` from `runserver`), the label became `127.0.0.1:8000: user` and FreeOTP rejected the QR code.

Fixes #768

## How Has This Been Tested?

Added `test_get_otpauth_url_replaces_colons` covering a `host:port` issuer (the #768 case) and a colon in the account name. Existing `get_otpauth_url` cases are unchanged.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.