### PR TITLE
Fix numeric keyboard on devices for OTP

### DIFF
--- a/tests/test_views_login.py
+++ b/tests/test_views_login.py
@@ -246,7 +246,7 @@ class LoginTest(UserMixin, TestCase):
                                'login_view-current_step': 'auth'})
         self.assertContains(response, 'Token:')
         self.assertContains(response, 'autofocus="autofocus"')
-        self.assertContains(response, 'pattern="[0-9]*"')
+        self.assertContains(response, 'inputmode="numeric"')
         self.assertContains(response, 'autocomplete="one-time-code"')
 
         response = self._post({'token-otp_token': '123456',

--- a/two_factor/forms.py
+++ b/two_factor/forms.py
@@ -112,7 +112,7 @@ class AuthenticationTokenForm(OTPAuthenticationFormMixin, forms.Form):
                                  max_length=totp_digits())
     otp_token.widget.attrs.update({
         'autofocus': 'autofocus',
-        'pattern': '[0-9]*',  # hint to show numeric keyboard for on-screen keyboards
+        'inputmode': 'numeric',
         'autocomplete': 'one-time-code',
     })
 


### PR DESCRIPTION
`AuthenticationTokenForm` now shows numeric keyboard on mobile devices.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Updated the `otp_token` field on `AuthenticationTokenForm` to have `inputmode="numeric"` instead of the old `pattern="[0-9]*"` hint.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Unlike most other forms for entering a `one-time-code`, the `inputmode` has not been set on the form field, and the old code does not work anymore.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I have tested this locally in my own project, where I had to override. This is how it caught my attention.

## Screenshots (if appropriate):
n/a

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
