### PR TITLE
Setup wizard: don't reset state on a GET while in progress

### DIFF
--- a/tests/test_views_setup.py
+++ b/tests/test_views_setup.py
@@ -67,6 +67,30 @@ class SetupTest(UserMixin, TestCase):
         self.assertRedirects(response, reverse('two_factor:setup_complete'))
         self.assertEqual(1, self.user.totpdevice_set.count())
 
+    @method_registry(['generator'])
+    def test_setup_generator_key_survives_stray_get(self):
+        # A GET to the setup URL restarts the wizard by design, but a
+        # background GET some browsers send while the user is mid-setup
+        # (see issue #767) must not silently drop the key used to
+        # validate the token, or the in-progress step.
+        self.client.post(
+            reverse('two_factor:setup'),
+            data={'setup_view-current_step': 'welcome'})
+        response = self.client.post(
+            reverse('two_factor:setup'),
+            data={'setup_view-current_step': 'generator'})
+        key = response.context_data['keys'].get('generator')
+        bin_key = unhexlify(key.encode())
+
+        self.client.get(reverse('two_factor:setup'))
+
+        response = self.client.post(
+            reverse('two_factor:setup'),
+            data={'setup_view-current_step': 'generator',
+                  'generator-token': totp(bin_key)})
+        self.assertRedirects(response, reverse('two_factor:setup_complete'))
+        self.assertEqual(1, self.user.totpdevice_set.count())
+
     @override_settings(TWO_FACTOR_CALL_GATEWAY='two_factor.gateways.fake.Fake',
                        TWO_FACTOR_SMS_GATEWAY='two_factor.gateways.fake.Fake')
     def test_setup_generator_with_multi_method(self):

--- a/two_factor/views/core.py
+++ b/two_factor/views/core.py
@@ -482,6 +482,14 @@ class SetupView(DeviceContextDataMixin, RedirectURLMixin, IdempotentSessionWizar
         """
         if default_device(self.request.user):
             return redirect(self.get_success_url())
+        if self.storage.current_step is not None:
+            # A wizard is already in progress. WizardView.get() always
+            # resets the wizard, but some browsers send a background GET
+            # to the current page while the user is mid-setup (see issue
+            # #767). Resetting here would silently drop the TOTP secret
+            # already shown to the user, so every later token submission
+            # would fail against a key that no longer matches it.
+            return self.render(self.get_form())
         return super().get(request, *args, **kwargs)
 
     def get_form(self, step=None, **kwargs):


### PR DESCRIPTION
Fixes #767.

SetupView.get() falls through to WizardView.get(), which resets the wizard on every GET, including the just-generated TOTP secret. If a browser sends a background GET to the setup URL while the form is still open (dev tools, prefetch, a second tab), the secret is silently replaced. The token the user later submits, generated from the secret shown in the QR code, then fails validation against a different key, and setup can never complete.

SetupView.get() now only resets when no wizard is in progress. It re-renders the current step from existing state otherwise.

Added a test that posts through to the generator step, fires a GET at the same URL to simulate the stray request, then confirms the originally shown key still validates. It fails on master (200 instead of a redirect) and passes with the fix.

Ran the full test suite (162 passed) plus the webauthn plugin tests, ruff, and isort.