### PR TITLE
Fix phonenumber 0001_initial leaving two_factor_phonedevice table uncreated

### DIFF
--- a/tests/test_migrations_phonenumber.py
+++ b/tests/test_migrations_phonenumber.py
@@ -1,0 +1,86 @@
+"""Regression tests for the phonenumber plugin migrations.
+
+The phonenumber app's first migration (``0001_initial``) historically used
+``SeparateDatabaseAndState`` with only ``state_operations``. That meant
+installing the ``phonenumber`` plugin *after* the ``two_factor`` migrations
+had already run would record the state of ``PhoneDevice`` but never create
+the underlying ``two_factor_phonedevice`` table. See issue #800.
+
+The fix introduces a shared ``CreatePhoneDevice`` operation that performs
+the actual ``CreateModel`` whenever the table is missing, and uses it from
+both ``0001_initial`` and ``0001_squashed_0001_initial``.
+"""
+
+from django.apps import apps
+from django.core.management import call_command
+from django.db import connection
+from django.db.migrations.recorder import MigrationRecorder
+from django.test import TransactionTestCase
+
+
+PHONE_DEVICE_TABLE = "two_factor_phonedevice"
+
+
+def _has_table(table_name):
+    return table_name in connection.introspection.table_names()
+
+
+def _drop_phone_device_table():
+    """Drop the phonenumber table via the schema editor if it exists."""
+    model = apps.get_model("phonenumber", "PhoneDevice")
+    with connection.schema_editor() as editor:
+        if PHONE_DEVICE_TABLE in connection.introspection.table_names():
+            editor.delete_model(model)
+
+
+def _unrecord_migration(app, name):
+    """Remove a single ``(app, name)`` entry from django_migrations."""
+    recorder = MigrationRecorder(connection)
+    recorder.record_unapplied(app, name)
+
+
+class PhonenumberInitialMigrationCreatesTableTest(TransactionTestCase):
+    """End-to-end regression test for issue #800."""
+
+    def test_initial_migration_creates_table_when_missing(self):
+        """``0001_initial`` must create the table if it is missing.
+
+        Simulates the scenario from the bug report: ``two_factor`` was
+        migrated first, then ``two_factor.plugins.phonenumber`` was added
+        to ``INSTALLED_APPS`` and migrated afterwards. Before the fix,
+        ``0001_initial`` would record the state but leave the database
+        without the ``two_factor_phonedevice`` table.
+        """
+        # The test runner already applied phonenumber migrations, including
+        # 0001_initial, so the table currently exists.
+        self.assertTrue(_has_table(PHONE_DEVICE_TABLE))
+
+        # Forget that 0001_initial was applied and drop the table to
+        # simulate the bug scenario, then re-run the migration.
+        _unrecord_migration("phonenumber", "0001_initial")
+        _drop_phone_device_table()
+        self.assertFalse(_has_table(PHONE_DEVICE_TABLE))
+
+        call_command("migrate", "phonenumber", "0001_initial", verbosity=0)
+
+        self.assertTrue(
+            _has_table(PHONE_DEVICE_TABLE),
+            "0001_initial must create two_factor_phonedevice",
+        )
+
+
+class CreatePhoneDeviceOperationTest(TransactionTestCase):
+    """Direct unit tests for the shared ``CreatePhoneDevice`` operation."""
+
+    def test_noop_when_table_already_exists(self):
+        """The operation must be a safe no-op when the table exists.
+
+        Mirrors the upgrade path described in the operation's docstring:
+        a database that already has ``two_factor_phonedevice`` (because
+        the original ``two_factor`` app created it before the squashed
+        migration existed) must not be re-created.
+        """
+        self.assertTrue(_has_table(PHONE_DEVICE_TABLE))
+        # Running the migration again must succeed without raising.
+        call_command("migrate", "phonenumber", "0001_initial", verbosity=0)
+        self.assertTrue(_has_table(PHONE_DEVICE_TABLE))

--- a/two_factor/plugins/phonenumber/migrations/0001_initial.py
+++ b/two_factor/plugins/phonenumber/migrations/0001_initial.py
@@ -1,10 +1,7 @@
-import django.db.models.deletion
-import django_otp.util
-import phonenumber_field.modelfields
 from django.conf import settings
-from django.db import migrations, models
+from django.db import migrations
 
-import two_factor.plugins.phonenumber.models
+from ._operations import CreatePhoneDevice
 
 
 class Migration(migrations.Migration):
@@ -16,38 +13,5 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.SeparateDatabaseAndState(
-            state_operations=[
-                migrations.CreateModel(
-                    name='PhoneDevice',
-                    fields=[
-                        ('id',
-                         models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                        ('name', models.CharField(help_text='The human-readable name of this device.', max_length=64)),
-                        ('confirmed', models.BooleanField(default=True, help_text='Is this device ready for use?')),
-                        ('throttling_failure_timestamp', models.DateTimeField(
-                            blank=True, default=None,
-                            help_text='A timestamp of the last failed verification attempt. '
-                                      'Null if last attempt succeeded.',
-                            null=True)),
-                        ('throttling_failure_count',
-                         models.PositiveIntegerField(default=0, help_text='Number of successive failed attempts.')),
-                        ('number', phonenumber_field.modelfields.PhoneNumberField(max_length=128, region=None)),
-                        ('key', models.CharField(default=django_otp.util.random_hex,
-                                                 help_text='Hex-encoded secret key',
-                                                 max_length=40,
-                                                 validators=[two_factor.plugins.phonenumber.models.key_validator])),
-                        ('method',
-                         models.CharField(choices=[('call', 'Phone Call'), ('sms', 'Text Message')], max_length=4,
-                                          verbose_name='method')),
-                        ('user', models.ForeignKey(help_text='The user that this device belongs to.',
-                                                   on_delete=django.db.models.deletion.CASCADE,
-                                                   to=settings.AUTH_USER_MODEL)),
-                    ],
-                    options={
-                        'db_table': 'two_factor_phonedevice',
-                    },
-                ),
-            ],
-        ),
+        CreatePhoneDevice(),
     ]

--- a/two_factor/plugins/phonenumber/migrations/0001_squashed_0001_initial.py
+++ b/two_factor/plugins/phonenumber/migrations/0001_squashed_0001_initial.py
@@ -1,73 +1,7 @@
-import django_otp.util
-import phonenumber_field.modelfields
 from django.conf import settings
-from django.db import migrations, models
-from django.db.migrations.operations.base import Operation
+from django.db import migrations
 
-import two_factor.plugins.phonenumber.models
-
-
-class CreatePhoneDevice(Operation):
-    """This fixes the problem described in
-    https://github.com/jazzband/django-two-factor-auth/issues/611
-
-    The problem was that the database can be in two different states when this
-    migration is run. The first state is when we upgrade from an older version
-    that has the two_factor_phonedevice already created by the two-factor app.
-    In this case we should not create the two_factor_phonedevice database table.
-    The second state is when the old two-factor migrations haven't been run and
-    we need to create the table.
-
-    Using this custom operation we check whether the table exists before
-    creating it.
-    """
-
-    reversible = False
-    create_model_operation = migrations.CreateModel(
-        name='PhoneDevice',
-        fields=[
-            ('id',
-             models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-            ('name', models.CharField(help_text='The human-readable name of this device.', max_length=64)),
-            ('confirmed', models.BooleanField(default=True, help_text='Is this device ready for use?')),
-            ('throttling_failure_timestamp', models.DateTimeField(
-                blank=True, default=None,
-                help_text='A timestamp of the last failed verification attempt. '
-                'Null if last attempt succeeded.',
-                null=True)),
-            ('throttling_failure_count',
-             models.PositiveIntegerField(default=0, help_text='Number of successive failed attempts.')),
-            ('number', phonenumber_field.modelfields.PhoneNumberField(max_length=128, region=None)),
-            ('key', models.CharField(default=django_otp.util.random_hex,
-                                     help_text='Hex-encoded secret key',
-                                     max_length=40,
-                                     validators=[two_factor.plugins.phonenumber.models.key_validator])),
-            ('method',
-             models.CharField(choices=[('call', 'Phone Call'), ('sms', 'Text Message')], max_length=4,
-                              verbose_name='method')),
-            ('user', models.ForeignKey(help_text='The user that this device belongs to.',
-                                       on_delete=models.deletion.CASCADE,
-                                       to=settings.AUTH_USER_MODEL)),
-        ],
-        options={
-            'db_table': 'two_factor_phonedevice',
-        },
-    )
-
-    def state_forwards(self, app_label, state):
-        self.create_model_operation.state_forwards(app_label, state)
-
-    def database_forwards(self, app_label, schema_editor, from_state, to_state):
-        if "two_factor_phonedevice" not in schema_editor.connection.introspection.table_names():
-            # The table doesn't exist. This means we aren't upgrading from a
-            # previous version where the two_factor app created the table and
-            # need to create the table.
-            to_state = from_state.clone()
-            self.create_model_operation.state_forwards(app_label, to_state)
-            self.create_model_operation.database_forwards(app_label, schema_editor, from_state, to_state)
-
-    def describe(self):
-        return "Create PhoneDevice"
+from ._operations import CreatePhoneDevice
 
 
 class Migration(migrations.Migration):

--- a/two_factor/plugins/phonenumber/migrations/_operations.py
+++ b/two_factor/plugins/phonenumber/migrations/_operations.py
@@ -1,0 +1,81 @@
+"""Shared migration operations for the phonenumber plugin.
+
+The custom ``CreatePhoneDevice`` operation lives here so that both
+``0001_initial`` and ``0001_squashed_0001_initial`` can reuse it. Without
+this sharing, an installation that migrates the ``two_factor`` app first
+and only later enables ``two_factor.plugins.phonenumber`` would end up
+recording ``0001_initial`` as applied (state-only) and never create the
+``two_factor_phonedevice`` database table.
+"""
+
+import django_otp.util
+import phonenumber_field.modelfields
+from django.conf import settings
+from django.db import migrations, models
+from django.db.migrations.operations.base import Operation
+
+import two_factor.plugins.phonenumber.models
+
+
+class CreatePhoneDevice(Operation):
+    """Create the ``two_factor_phonedevice`` table if it does not exist.
+
+    The database can be in two different states when this migration is run.
+
+    1. Upgrading from an older version that has the ``two_factor_phonedevice``
+       table already created by the ``two_factor`` app. In this case we
+       should not create the table.
+    2. A fresh install, or an install where ``two_factor.plugins.phonenumber``
+       was added to ``INSTALLED_APPS`` after the ``two_factor`` migrations
+       have already run. In this case we must create the table.
+
+    Using this custom operation we check whether the table exists before
+    creating it.
+    """
+
+    reversible = False
+    create_model_operation = migrations.CreateModel(
+        name='PhoneDevice',
+        fields=[
+            ('id',
+             models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+            ('name', models.CharField(help_text='The human-readable name of this device.', max_length=64)),
+            ('confirmed', models.BooleanField(default=True, help_text='Is this device ready for use?')),
+            ('throttling_failure_timestamp', models.DateTimeField(
+                blank=True, default=None,
+                help_text='A timestamp of the last failed verification attempt. '
+                          'Null if last attempt succeeded.',
+                null=True)),
+            ('throttling_failure_count',
+             models.PositiveIntegerField(default=0, help_text='Number of successive failed attempts.')),
+            ('number', phonenumber_field.modelfields.PhoneNumberField(max_length=128, region=None)),
+            ('key', models.CharField(default=django_otp.util.random_hex,
+                                     help_text='Hex-encoded secret key',
+                                     max_length=40,
+                                     validators=[two_factor.plugins.phonenumber.models.key_validator])),
+            ('method',
+             models.CharField(choices=[('call', 'Phone Call'), ('sms', 'Text Message')], max_length=4,
+                              verbose_name='method')),
+            ('user', models.ForeignKey(help_text='The user that this device belongs to.',
+                                       on_delete=models.deletion.CASCADE,
+                                       to=settings.AUTH_USER_MODEL)),
+        ],
+        options={
+            'db_table': 'two_factor_phonedevice',
+        },
+    )
+
+    def state_forwards(self, app_label, state):
+        self.create_model_operation.state_forwards(app_label, state)
+
+    def database_forwards(self, app_label, schema_editor, from_state, to_state):
+        if "two_factor_phonedevice" not in schema_editor.connection.introspection.table_names():
+            # The table doesn't exist. This means we aren't upgrading from a
+            # previous version where the two_factor app created the table and
+            # need to create the table.
+            to_state = from_state.clone()
+            self.create_model_operation.state_forwards(app_label, to_state)
+            self.create_model_operation.database_forwards(app_label, schema_editor, from_state, to_state)
+
+    def describe(self):
+        return "Create PhoneDevice"


### PR DESCRIPTION
## Description

The `two_factor.plugins.phonenumber` app's `0001_initial` migration used `SeparateDatabaseAndState` with only `state_operations`. When a project that already had `two_factor` migrated added `two_factor.plugins.phonenumber` to `INSTALLED_APPS` and migrated, `0001_initial` was recorded as applied without ever creating the `two_factor_phonedevice` database table. The squashed `0001_squashed_0001_initial` was then skipped because Django saw `0001_initial` as already applied, leaving the schema with no `PhoneDevice` table and no way to enable SMS or phone-call authentication without manual intervention.

This change extracts the custom `CreatePhoneDevice` operation into a shared module (`two_factor/plugins/phonenumber/migrations/_operations.py`) and uses it from both `0001_initial` and `0001_squashed_0001_initial`. The operation checks whether `two_factor_phonedevice` already exists and creates it only when missing, which preserves the upgrade safety from #611 (a database that already has the table from the old `two_factor` app is left untouched) while also creating the table on a fresh `0001_initial` run.

## Motivation and Context

Fixes #800.

Before the fix, the only ways to recover a system affected by this bug were:

1. Drop the phonenumber `0001_initial` row from `django_migrations`, then re-run the squashed migration, or
2. Manually create the `two_factor_phonedevice` table.

After the fix, the next `migrate` after adding the app to `INSTALLED_APPS` creates the table.

## How Has This Been Tested?

Added `tests/test_migrations_phonenumber.py` covering both code paths:

- `test_initial_migration_creates_table_when_missing`: drops the table, un-records `phonenumber.0001_initial`, and verifies that running `migrate phonenumber 0001_initial` recreates it. This fails against the original code.
- `test_noop_when_table_already_exists`: verifies that running the migration against a database that already has `two_factor_phonedevice` does not raise.

```
$ DJANGO_SETTINGS_MODULE=tests.settings PYTHONPATH=. django-admin test tests
Ran 163 tests in 12.667s
OK
```

`makemigrations --dry-run --check` reports no missing migrations.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
